### PR TITLE
Add Helm chart validation checks

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -23,9 +23,33 @@ jobs:
       - name: Run yamllint
         run: yamllint .
 
+      - name: Install markdownlint
+        run: |
+          npm install -g markdownlint-cli
+
+      - name: Lint Markdown files
+        run: markdownlint '**/*.md'
+
       - name: Lint all charts
         run: |
           for chart in charts/*; do
             helm dependency update "$chart" || true
             helm lint "$chart"
           done
+
+      - name: Install kubeval
+        run: |
+          curl -L https://github.com/instrumenta/kubeval/releases/download/v0.16.1/kubeval-linux-amd64.tar.gz -o kubeval.tar.gz
+          tar xzf kubeval.tar.gz
+          sudo install -o root -g root -m 0755 kubeval /usr/local/bin/kubeval
+
+      - name: Render and validate charts
+        run: |
+          for chart in charts/*; do
+            helm template "$chart" | kubeval - --ignore-missing-schemas
+          done
+
+      - name: Check Artifact Hub readiness
+        run: |
+          sudo apt-get update && sudo apt-get install -y yq
+          ./scripts/check-artifacthub.sh

--- a/scripts/check-artifacthub.sh
+++ b/scripts/check-artifacthub.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+required=(license maintainers)
+for chart in charts/*; do
+  for key in "${required[@]}"; do
+    value=$(yq ".${key}" "$chart/Chart.yaml")
+    if [[ "$value" == "null" ]]; then
+      echo "Missing $key in $chart/Chart.yaml" >&2
+      exit 1
+    fi
+  done
+  echo "$chart ready"
+done


### PR DESCRIPTION
## Summary
- lint Markdown files in workflow
- validate rendered chart templates with kubeval
- verify Artifact Hub required fields via script

## Testing
- `yamllint .`
- `markdownlint '**/*.md'` *(fails: line length issues)*
- `./scripts/check-artifacthub.sh` *(fails: Missing license)*

------
https://chatgpt.com/codex/tasks/task_e_6882a22216308320b83afdf8f1f74208