### PR TITLE
Add Docker MCP helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ This repository contains Helm charts used by the MCP project. All charts are sto
 - **gitlab** – Helm chart for the GitLab MCP server. See [its README](charts/gitlab/README.md) for usage information.
 - **kubernetes** – Helm chart for running the MCP server locally. See [its README](charts/kubernetes/README.md) for details.
 - **home-assistant** – Helm chart for deploying the Home Assistant MCP server. See [its README](charts/home-assistant/README.md).
+- **docker-mcp** – Helm chart for deploying Docker MCP server. See [its README](charts/docker-mcp/README.md).

--- a/charts/docker-mcp/.helmignore
+++ b/charts/docker-mcp/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/docker-mcp/Chart.yaml
+++ b/charts/docker-mcp/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: mcp-docker-helm
+description: A Helm chart for deploying Docker MCP server
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "latest"

--- a/charts/docker-mcp/README.md
+++ b/charts/docker-mcp/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Docker MCP Helm Chart
 
 This Helm chart deploys the Docker MCP server based on the `mcp/docker` Docker image to a Kubernetes cluster.
@@ -90,7 +91,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                                                                                 | `""`    |
 
 ## Configuration and installation details
-
 
 ### Exposing the application
 

--- a/charts/docker-mcp/README.md
+++ b/charts/docker-mcp/README.md
@@ -1,0 +1,143 @@
+# Docker MCP Helm Chart
+
+This Helm chart deploys the Docker MCP server based on the `mcp/docker` Docker image to a Kubernetes cluster.
+
+## Prerequisites
+
+- Kubernetes 1.16+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+To install the chart with the release name `docker-mcp`:
+
+```bash
+helm install docker-mcp ./charts/docker-mcp
+```
+
+The command deploys the MCP server on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `docker-mcp` deployment:
+
+```bash
+helm delete docker-mcp
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `replicaCount`           | Number of MCP replicas to deploy        | `1`   |
+| `nameOverride`           | String to partially override docker-mcp.fullname | `""`  |
+| `fullnameOverride`       | String to fully override docker-mcp.fullname   | `""`  |
+
+### Image parameters
+
+| Name                | Description                                          | Value                    |
+| ------------------- | ---------------------------------------------------- | ------------------------ |
+| `image.repository`  | MCP image repository                          | `mcp/docker` |
+| `image.tag`         | MCP image tag (immutable tags are recommended) | `latest`                 |
+| `image.pullPolicy`  | MCP image pull policy                         | `IfNotPresent`           |
+| `imagePullSecrets`  | MCP image pull secrets                        | `[]`                     |
+
+### Service Account parameters
+
+| Name                         | Description                                                | Value  |
+| ---------------------------- | ---------------------------------------------------------- | ------ |
+| `serviceAccount.create`      | Specifies whether a service account should be created     | `true` |
+| `serviceAccount.annotations` | Annotations to add to the service account                 | `{}`   |
+| `serviceAccount.name`        | The name of the service account to use                    | `""`   |
+
+### Service parameters
+
+| Name           | Description                        | Value       |
+| -------------- | ---------------------------------- | ----------- |
+| `service.type` | MCP service type            | `ClusterIP` |
+| `service.port` | MCP service HTTP port       | `8080`      |
+
+### Ingress parameters
+
+| Name                  | Description                                                | Value               |
+| --------------------- | ---------------------------------------------------------- | ------------------- |
+| `ingress.enabled`     | Enable ingress record generation for MCP          | `false`             |
+| `ingress.className`   | IngressClass that will be be used to implement the Ingress | `""`                |
+| `ingress.annotations` | Additional annotations for the Ingress resource           | `{}`                |
+| `ingress.hosts`       | An array with hosts and paths                             | `[{host: "mcp.local", paths: [{path: "/", pathType: "Prefix"}]}]` |
+| `ingress.tls`         | TLS configuration for ingress                             | `[]`                |
+
+### Environment variables
+
+| Name           | Description                                          | Value |
+| -------------- | ---------------------------------------------------- | ----- |
+| `env`          | Environment variables to be set on the container    | `{}`  |
+| `envSecrets`   | Environment variables from external secrets         | `{}`  |
+| `secretEnv`    | Environment variables to be set from created secret | `{}`  |
+
+### Autoscaling parameters
+
+| Name                                            | Description                                                                                                          | Value   |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------- |
+| `autoscaling.enabled`                           | Enable Horizontal Pod Autoscaler (HPA)                                                                              | `false` |
+| `autoscaling.minReplicas`                       | Minimum number of MCP replicas                                                                               | `1`     |
+| `autoscaling.maxReplicas`                       | Maximum number of MCP replicas                                                                               | `100`   |
+| `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                                                                    | `80`    |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                                                                                 | `""`    |
+
+## Configuration and installation details
+
+
+### Exposing the application
+
+To access the MCP server from outside the cluster, you can:
+
+1. **Use port forwarding** (for development):
+
+   ```bash
+   kubectl port-forward svc/docker-mcp 8080:8080
+   ```
+
+2. **Enable ingress** (for production):
+
+   ```yaml
+   ingress:
+     enabled: true
+     className: "nginx"
+     hosts:
+       - host: docker-mcp.your-domain.com
+         paths:
+           - path: /
+             pathType: Prefix
+   ```
+
+3. **Use LoadBalancer service type**:
+
+   ```yaml
+   service:
+     type: LoadBalancer
+   ```
+
+## Troubleshooting
+
+### Check pod status
+
+```bash
+kubectl get pods -l app.kubernetes.io/name=docker-mcp-helm
+```
+
+### Check logs
+
+```bash
+kubectl logs -l app.kubernetes.io/name=docker-mcp-helm
+```
+
+### Test connection
+
+```bash
+helm test docker-mcp
+```

--- a/charts/docker-mcp/templates/NOTES.txt
+++ b/charts/docker-mcp/templates/NOTES.txt
@@ -1,0 +1,23 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mcp-docker-helm.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mcp-docker-helm.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mcp-docker-helm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mcp-docker-helm.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+

--- a/charts/docker-mcp/templates/NOTES.txt
+++ b/charts/docker-mcp/templates/NOTES.txt
@@ -11,7 +11,7 @@
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mcp-docker-helm.fullname" . }}'
+           You can watch the status of the service by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mcp-docker-helm.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mcp-docker-helm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}

--- a/charts/docker-mcp/templates/_helpers.tpl
+++ b/charts/docker-mcp/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-docker-helm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mcp-docker-helm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mcp-docker-helm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mcp-docker-helm.labels" -}}
+helm.sh/chart: {{ include "mcp-docker-helm.chart" . }}
+{{ include "mcp-docker-helm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mcp-docker-helm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-docker-helm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mcp-docker-helm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mcp-docker-helm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/docker-mcp/templates/deployment.yaml
+++ b/charts/docker-mcp/templates/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-docker-helm.fullname" . }}
+  labels:
+    {{- include "mcp-docker-helm.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "mcp-docker-helm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mcp-docker-helm.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mcp-docker-helm.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if or .Values.env .Values.envSecrets .Values.secretEnv.data }}
+          env:
+            {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: {{ quote $val }}
+            {{- end }}
+            {{- range $key, $val := .Values.envSecrets }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $val.secretName }}
+                  key: {{ $val.secretKey }}
+            {{- end }}
+            {{- if .Values.secretEnv.data }}
+            {{- range $key, $val := .Values.secretEnv.data }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "mcp-docker-helm.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/docker-mcp/templates/hpa.yaml
+++ b/charts/docker-mcp/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "mcp-docker-helm.fullname" . }}
+  labels:
+    {{- include "mcp-docker-helm.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "mcp-docker-helm.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/docker-mcp/templates/ingress.yaml
+++ b/charts/docker-mcp/templates/ingress.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mcp-docker-helm.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class")) }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mcp-docker-helm.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/docker-mcp/templates/secret.yaml
+++ b/charts/docker-mcp/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secretEnv.data }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mcp-docker-helm.fullname" . }}
+  labels:
+    {{- include "mcp-docker-helm.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $val := .Values.secretEnv.data }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/docker-mcp/templates/service.yaml
+++ b/charts/docker-mcp/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mcp-docker-helm.fullname" . }}
+  labels:
+    {{- include "mcp-docker-helm.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mcp-docker-helm.selectorLabels" . | nindent 4 }}

--- a/charts/docker-mcp/templates/serviceaccount.yaml
+++ b/charts/docker-mcp/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-docker-helm.serviceAccountName" . }}
+  labels:
+    {{- include "mcp-docker-helm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/docker-mcp/templates/tests/test-connection.yaml
+++ b/charts/docker-mcp/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mcp-docker-helm.fullname" . }}-test-connection"
+  labels:
+    {{- include "mcp-docker-helm.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "mcp-docker-helm.fullname" . }}:{{ .Values.service.port }}']

--- a/charts/docker-mcp/values.yaml
+++ b/charts/docker-mcp/values.yaml
@@ -1,0 +1,96 @@
+# Default values for mcp-docker-helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: mcp/docker
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8080
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: mcp.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Environment variables for the MCP server
+# Example:
+# env:
+#   MCP_OPTION: "value"
+env: {}
+
+# Environment variables from secrets
+envSecrets: {}
+
+# Secret configuration for sensitive data
+secretEnv:
+  data: {}


### PR DESCRIPTION
## Summary
- add docker-mcp chart for deploying `mcp/docker`
- document the chart in the repo README

## Testing
- `yamllint charts/docker-mcp/Chart.yaml charts/docker-mcp/values.yaml`
- `markdownlint charts/docker-mcp/README.md ../README.md` *(fails: MD013 line length warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688342dd4ba4832089c1e9e90583b99e

## Summary by Sourcery

Add a new Helm chart for deploying the Docker MCP server and update repository documentation accordingly

New Features:
- Introduce a docker-mcp Helm chart for deploying the MCP Docker image with templates for deployment, service, ingress, autoscaling, secrets, service account, and test connection hook
- Document the new docker-mcp chart in the root repository README and include a dedicated README for chart usage