### PR TITLE
Add Helm chart dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,32 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+ARG HELM_VERSION=v3.13.1
+RUN curl -sL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -o helm.tar.gz \
+    && tar -xzf helm.tar.gz \
+    && mv linux-amd64/helm /usr/local/bin/helm \
+    && rm -rf helm.tar.gz linux-amd64
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    yamllint \
+    curl \
+    ca-certificates \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js for markdownlint
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g markdownlint-cli \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG KUBEVAL_VERSION=v0.16.1
+RUN curl -sL https://github.com/instrumenta/kubeval/releases/download/${KUBEVAL_VERSION}/kubeval-linux-amd64.tar.gz -o kubeval.tar.gz \
+    && tar -xzf kubeval.tar.gz \
+    && install -o root -g root -m 0755 kubeval /usr/local/bin/kubeval \
+    && rm -f kubeval kubeval.tar.gz
+
+ARG YQ_VERSION=4.43.1
+RUN curl -sL https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 -o /usr/local/bin/yq \
+    && chmod +x /usr/local/bin/yq
+
+CMD ["bash"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Node.js for markdownlint
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
     && apt-get install -y nodejs \
-    && npm install -g markdownlint-cli \
+    && npm install -g markdownlint-cli@0.39.0 \
     && rm -rf /var/lib/apt/lists/*
 
 ARG KUBEVAL_VERSION=v0.16.1
@@ -29,4 +29,6 @@ ARG YQ_VERSION=4.43.1
 RUN curl -sL https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 -o /usr/local/bin/yq \
     && chmod +x /usr/local/bin/yq
 
+RUN useradd -ms /bin/bash devuser
+USER devuser
 CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+    "name": "Helm Charts Dev Container",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-kubernetes-tools.vscode-kubernetes-tools",
+                "redhat.vscode-yaml",
+                "DavidAnson.vscode-markdownlint"
+            ]
+        }
+    },
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+    "postCreateCommand": "helm version && yamllint --version && markdownlint --version && kubeval --version && yq --version"
+}

--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ This repository contains Helm charts used by the MCP project. All charts are sto
 - **gitlab** – Helm chart for the GitLab MCP server. See [its README](charts/gitlab/README.md) for usage information.
 - **kubernetes** – Helm chart for running the MCP server locally. See [its README](charts/kubernetes/README.md) for details.
 - **home-assistant** – Helm chart for deploying the Home Assistant MCP server. See [its README](charts/home-assistant/README.md).
+
+## Development container
+
+A [Dev Container](https://containers.dev/) configuration is provided in the `.devcontainer` directory. It includes Helm and related tools to lint and test the charts locally.


### PR DESCRIPTION
## Summary
- add dev container with Helm tooling
- document how to use the dev container

## Testing
- `yamllint .`
- `markdownlint '**/*.md'` *(fails: many warnings)*
- `for chart in charts/*; do helm dependency update "$chart" || true; helm lint "$chart"; done`
- `for chart in charts/*; do helm template "$chart" | kubeval - --ignore-missing-schemas; done`
- `./scripts/check-artifacthub.sh` *(fails: Missing license in charts/atlassian/Chart.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68834b292190832093994aac2bc21e6d

## Summary by Sourcery

Add a development container configuration to streamline Helm chart linting and testing.

New Features:
- Provide a dev container setup under .devcontainer for Helm chart development.

Enhancements:
- Install Helm, yamllint, markdownlint-cli, kubeval, yq, Node.js, and other dependencies in the dev container.

Documentation:
- Add a Development container section to the README.