### PR TITLE
Fix markdown lint

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+default: true
+MD013: false

--- a/charts/atlassian/README.md
+++ b/charts/atlassian/README.md
@@ -41,4 +41,3 @@ A Helm chart for Kubernetes
 | env | object | `{}` | Extra environment variables |
 | envSecrets | object | `{}` | Environment variables from secrets |
 | secretEnv | object | `{}` | Create secret with environment data; keys must be valid secret keys and values cannot be empty |
-

--- a/charts/kubernetes/README.md
+++ b/charts/kubernetes/README.md
@@ -91,7 +91,6 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration and installation details
 
-
 ### Exposing the application
 
 To access the MCP server from outside the cluster, you can:


### PR DESCRIPTION
## Summary
- add markdownlint config to disable line-length rule
- clean up blank lines in chart READMEs

## Testing
- `markdownlint '**/*.md'`
- `yamllint .`
- `helm lint charts/*`
- `helm template "$chart" | kubeval - --ignore-missing-schemas`

------
https://chatgpt.com/codex/tasks/task_e_68837af2a0e483208b8d35ad0e5d2092