### PR TITLE
Add Helm chart release workflow

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,0 +1,36 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'charts/**'
+      - '.github/workflows/chart-release.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        with:
+          charts_dir: charts
+          pages_branch: gh-pages
+        env:
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and publish Helm charts to `gh-pages`
- trigger chart publishing when the workflow file itself changes

## Testing
- `yamllint .`
- `markdownlint '**/*.md'`
- `helm lint` on all charts
- render charts with `kubeval`
- `./scripts/check-artifacthub.sh`


------
https://chatgpt.com/codex/tasks/task_e_6883970f2d6083208cb19c65188bc157

## Summary by Sourcery

CI:
- Add chart-release workflow to build and publish Helm charts to gh-pages on pushes to master or manual dispatch