### PR TITLE
Add shared helper library chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains Helm charts used by the MCP project. All charts are sto
 - **home-assistant** – Helm chart for deploying the Home Assistant MCP server. See [its README](charts/home-assistant/README.md).
 - **docker-mcp** – Helm chart for deploying Docker MCP server. See [its README](charts/docker-mcp/README.md).
 - **mcpo** – Helm chart for deploying the mcpo proxy server. See [its README](charts/mcpo/README.md).
+- **mcp-library** – Library chart providing common helper templates.
 
 ## Development container
 

--- a/charts/atlassian/Chart.yaml
+++ b/charts/atlassian/Chart.yaml
@@ -24,4 +24,8 @@ version: 0.1.3
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+dependencies:
+  - name: mcp-library
+    version: 0.1.0
+    repository: "file://../mcp-library"
 appVersion: "1.16.0"

--- a/charts/atlassian/templates/_helpers.tpl
+++ b/charts/atlassian/templates/_helpers.tpl
@@ -1,62 +1,23 @@
-{{/*
-Expand the name of the chart.
-*/}}
 {{- define "mcp-atlassian-helm.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.name" . }}
 {{- end }}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
 {{- define "mcp-atlassian-helm.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{ include "mcp-library.fullname" . }}
 {{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
 {{- define "mcp-atlassian-helm.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.chart" . }}
 {{- end }}
 
-{{/*
-Common labels
-*/}}
 {{- define "mcp-atlassian-helm.labels" -}}
-helm.sh/chart: {{ include "mcp-atlassian-helm.chart" . }}
-{{ include "mcp-atlassian-helm.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "mcp-library.labels" . }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
 {{- define "mcp-atlassian-helm.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "mcp-atlassian-helm.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "mcp-library.selectorLabels" . }}
 {{- end }}
 
-{{/*
-Create the name of the service account to use
-*/}}
 {{- define "mcp-atlassian-helm.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "mcp-atlassian-helm.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{ include "mcp-library.serviceAccountName" . }}
 {{- end }}

--- a/charts/docker-mcp/Chart.yaml
+++ b/charts/docker-mcp/Chart.yaml
@@ -24,4 +24,8 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+dependencies:
+  - name: mcp-library
+    version: 0.1.0
+    repository: "file://../mcp-library"
 appVersion: "latest"

--- a/charts/docker-mcp/templates/_helpers.tpl
+++ b/charts/docker-mcp/templates/_helpers.tpl
@@ -1,62 +1,23 @@
-{{/*
-Expand the name of the chart.
-*/}}
 {{- define "mcp-docker-helm.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.name" . }}
 {{- end }}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
 {{- define "mcp-docker-helm.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{ include "mcp-library.fullname" . }}
 {{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
 {{- define "mcp-docker-helm.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.chart" . }}
 {{- end }}
 
-{{/*
-Common labels
-*/}}
 {{- define "mcp-docker-helm.labels" -}}
-helm.sh/chart: {{ include "mcp-docker-helm.chart" . }}
-{{ include "mcp-docker-helm.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "mcp-library.labels" . }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
 {{- define "mcp-docker-helm.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "mcp-docker-helm.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "mcp-library.selectorLabels" . }}
 {{- end }}
 
-{{/*
-Create the name of the service account to use
-*/}}
 {{- define "mcp-docker-helm.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "mcp-docker-helm.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{ include "mcp-library.serviceAccountName" . }}
 {{- end }}

--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -24,4 +24,8 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+dependencies:
+  - name: mcp-library
+    version: 0.1.0
+    repository: "file://../mcp-library"
 appVersion: "latest"

--- a/charts/gitlab/templates/_helpers.tpl
+++ b/charts/gitlab/templates/_helpers.tpl
@@ -1,62 +1,23 @@
-{{/*
-Expand the name of the chart.
-*/}}
 {{- define "mcp-gitlab-helm.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.name" . }}
 {{- end }}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
 {{- define "mcp-gitlab-helm.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{ include "mcp-library.fullname" . }}
 {{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
 {{- define "mcp-gitlab-helm.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.chart" . }}
 {{- end }}
 
-{{/*
-Common labels
-*/}}
 {{- define "mcp-gitlab-helm.labels" -}}
-helm.sh/chart: {{ include "mcp-gitlab-helm.chart" . }}
-{{ include "mcp-gitlab-helm.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "mcp-library.labels" . }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
 {{- define "mcp-gitlab-helm.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "mcp-gitlab-helm.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "mcp-library.selectorLabels" . }}
 {{- end }}
 
-{{/*
-Create the name of the service account to use
-*/}}
 {{- define "mcp-gitlab-helm.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "mcp-gitlab-helm.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{ include "mcp-library.serviceAccountName" . }}
 {{- end }}

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -24,4 +24,8 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+dependencies:
+  - name: mcp-library
+    version: 0.1.0
+    repository: "file://../mcp-library"
 appVersion: "latest"

--- a/charts/home-assistant/templates/_helpers.tpl
+++ b/charts/home-assistant/templates/_helpers.tpl
@@ -1,62 +1,23 @@
-{{/*
-Expand the name of the chart.
-*/}}
 {{- define "mcp-home-assistant-helm.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.name" . }}
 {{- end }}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
 {{- define "mcp-home-assistant-helm.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{ include "mcp-library.fullname" . }}
 {{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
 {{- define "mcp-home-assistant-helm.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.chart" . }}
 {{- end }}
 
-{{/*
-Common labels
-*/}}
 {{- define "mcp-home-assistant-helm.labels" -}}
-helm.sh/chart: {{ include "mcp-home-assistant-helm.chart" . }}
-{{ include "mcp-home-assistant-helm.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "mcp-library.labels" . }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
 {{- define "mcp-home-assistant-helm.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "mcp-home-assistant-helm.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "mcp-library.selectorLabels" . }}
 {{- end }}
 
-{{/*
-Create the name of the service account to use
-*/}}
 {{- define "mcp-home-assistant-helm.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "mcp-home-assistant-helm.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{ include "mcp-library.serviceAccountName" . }}
 {{- end }}

--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -24,4 +24,8 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+dependencies:
+  - name: mcp-library
+    version: 0.1.0
+    repository: "file://../mcp-library"
 appVersion: "latest"

--- a/charts/kubernetes/templates/_helpers.tpl
+++ b/charts/kubernetes/templates/_helpers.tpl
@@ -1,62 +1,23 @@
-{{/*
-Expand the name of the chart.
-*/}}
 {{- define "mcp-kubernetes-helm.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.name" . }}
 {{- end }}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
 {{- define "mcp-kubernetes-helm.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{ include "mcp-library.fullname" . }}
 {{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
 {{- define "mcp-kubernetes-helm.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.chart" . }}
 {{- end }}
 
-{{/*
-Common labels
-*/}}
 {{- define "mcp-kubernetes-helm.labels" -}}
-helm.sh/chart: {{ include "mcp-kubernetes-helm.chart" . }}
-{{ include "mcp-kubernetes-helm.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "mcp-library.labels" . }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
 {{- define "mcp-kubernetes-helm.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "mcp-kubernetes-helm.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "mcp-library.selectorLabels" . }}
 {{- end }}
 
-{{/*
-Create the name of the service account to use
-*/}}
 {{- define "mcp-kubernetes-helm.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "mcp-kubernetes-helm.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{ include "mcp-library.serviceAccountName" . }}
 {{- end }}

--- a/charts/mcp-library/Chart.yaml
+++ b/charts/mcp-library/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: mcp-library
+description: Common helper templates for MCP charts
+license: MIT
+maintainers:
+  - name: Open WebUI
+type: library
+version: 0.1.0
+appVersion: "1.0"

--- a/charts/mcp-library/README.md
+++ b/charts/mcp-library/README.md
@@ -1,0 +1,4 @@
+# mcp-library
+
+This chart provides common helper templates shared across MCP Helm charts.
+It is a library chart and is not meant to be deployed directly.

--- a/charts/mcp-library/templates/_helpers.tpl
+++ b/charts/mcp-library/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* Expand the name of the chart. */}}
+{{- define "mcp-library.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Create a default fully qualified app name. */}}
+{{- define "mcp-library.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "mcp-library.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Common labels */}}
+{{- define "mcp-library.labels" -}}
+helm.sh/chart: {{ include "mcp-library.chart" . }}
+{{ include "mcp-library.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Selector labels */}}
+{{- define "mcp-library.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-library.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* Create the name of the service account to use */}}
+{{- define "mcp-library.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mcp-library.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/mcpo/Chart.yaml
+++ b/charts/mcpo/Chart.yaml
@@ -24,4 +24,8 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
+dependencies:
+  - name: mcp-library
+    version: 0.1.0
+    repository: "file://../mcp-library"
 appVersion: "main"

--- a/charts/mcpo/templates/_helpers.tpl
+++ b/charts/mcpo/templates/_helpers.tpl
@@ -1,62 +1,23 @@
-{{/*
-Expand the name of the chart.
-*/}}
 {{- define "mcp-mcpo-helm.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.name" . }}
 {{- end }}
 
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
 {{- define "mcp-mcpo-helm.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
+{{ include "mcp-library.fullname" . }}
 {{- end }}
 
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
 {{- define "mcp-mcpo-helm.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "mcp-library.chart" . }}
 {{- end }}
 
-{{/*
-Common labels
-*/}}
 {{- define "mcp-mcpo-helm.labels" -}}
-helm.sh/chart: {{ include "mcp-mcpo-helm.chart" . }}
-{{ include "mcp-mcpo-helm.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ include "mcp-library.labels" . }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
 {{- define "mcp-mcpo-helm.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "mcp-mcpo-helm.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "mcp-library.selectorLabels" . }}
 {{- end }}
 
-{{/*
-Create the name of the service account to use
-*/}}
 {{- define "mcp-mcpo-helm.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "mcp-mcpo-helm.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{ include "mcp-library.serviceAccountName" . }}
 {{- end }}


### PR DESCRIPTION
## Summary
- create `mcp-library` library chart with common helper templates
- use the new library chart in all application charts
- delegate label and naming helpers to the library
- document the new chart in README

## Testing
- `yamllint .`
- `markdownlint '**/*.md'`
- `helm dependency update "$chart" && helm lint "$chart"` for each chart
- `helm template "$chart" | kubeval - --ignore-missing-schemas` for each chart
- `./scripts/check-artifacthub.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883e991d6c483209e20c41b27aa0d38

## Summary by Sourcery

Introduce a shared Helm library chart (mcp-library) for common helper templates and refactor all existing application charts to depend on and use this library, streamlining helper definitions and updating documentation.

New Features:
- Add mcp-library Helm library chart providing shared helper templates for naming, labeling, and service account management.

Enhancements:
- Refactor application charts to depend on mcp-library and replace inline helper definitions with library includes.
- Update Chart.yaml for each chart to declare mcp-library as a dependency.

Documentation:
- Document mcp-library in the top-level README and add a dedicated README for the library chart.