### PR TITLE
Add owner contact for Artifact Hub verification

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,5 @@
+repositoryID: 48fd68da-25bc-4207-9aeb-e731542de28b
+owners:
+  - name: Serge Arbuzov
+    email: info@whitediver.com
+


### PR DESCRIPTION
## Summary
- include owner info in `artifacthub-repo.yml`

## Testing
- `bash scripts/check-artifacthub.sh`


------
https://chatgpt.com/codex/tasks/task_e_68840f9fc514832089dafc3661b923eb

## Summary by Sourcery

Enhancements:
- Add artifacthub-repo.yml to configure repositoryID and owner contact details for Artifact Hub verification