### PR TITLE
Update chart dependencies

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -26,6 +26,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Add MCP chart repository
+        run: helm repo add mcp https://arbuzov.github.io/mcp-helm/
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           version: v3.13.1
 
+      - name: Add MCP chart repository
+        run: helm repo add mcp https://arbuzov.github.io/mcp-helm/
+
       - name: Install yamllint
         run: sudo apt-get update && sudo apt-get install -y yamllint
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ This repository contains Helm charts used by the MCP project. All charts are sto
 ## Development container
 
 A [Dev Container](https://containers.dev/) configuration is provided in the `.devcontainer` directory. It includes Helm and related tools to lint and test the charts locally.
+
+## Using the chart repository
+
+When working with charts that depend on the `mcp-library` chart, add this repository so Helm can resolve the dependency:
+
+```bash
+helm repo add mcp https://arbuzov.github.io/mcp-helm/
+```
+
+After adding the repository, run `helm dependency update` inside the chart directory to fetch the required dependencies.

--- a/charts/atlassian/Chart.yaml
+++ b/charts/atlassian/Chart.yaml
@@ -27,5 +27,5 @@ version: 0.1.3
 dependencies:
   - name: mcp-library
     version: 0.1.0
-    repository: "file://../mcp-library"
+    repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "1.16.0"

--- a/charts/docker-mcp/Chart.yaml
+++ b/charts/docker-mcp/Chart.yaml
@@ -27,5 +27,5 @@ version: 0.1.0
 dependencies:
   - name: mcp-library
     version: 0.1.0
-    repository: "file://../mcp-library"
+    repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "latest"

--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -27,5 +27,5 @@ version: 0.1.0
 dependencies:
   - name: mcp-library
     version: 0.1.0
-    repository: "file://../mcp-library"
+    repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "latest"

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -27,5 +27,5 @@ version: 0.1.0
 dependencies:
   - name: mcp-library
     version: 0.1.0
-    repository: "file://../mcp-library"
+    repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "latest"

--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -27,5 +27,5 @@ version: 0.1.0
 dependencies:
   - name: mcp-library
     version: 0.1.0
-    repository: "file://../mcp-library"
+    repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "latest"

--- a/charts/mcpo/Chart.yaml
+++ b/charts/mcpo/Chart.yaml
@@ -27,5 +27,5 @@ version: 0.1.0
 dependencies:
   - name: mcp-library
     version: 0.1.0
-    repository: "file://../mcp-library"
+    repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "main"


### PR DESCRIPTION
## Summary
- add instructions to use the hosted Helm chart repo
- reference the hosted repo for `mcp-library` dependencies
- make GH actions add the repo before linting or releasing

## Testing
- `yamllint .`
- `markdownlint '**/*.md'`
- `helm dependency update charts/gitlab` *(fails: mcp-library chart not found)*
- `helm lint charts/gitlab` *(fails: template error due to missing dependency)*
- `for chart in charts/*; do helm template "$chart" | kubeval - --ignore-missing-schemas; done`

------
https://chatgpt.com/codex/tasks/task_e_68847b5c03088320bf5009c867caee9b