### PR TITLE
Improve chart release automation

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   release:
+    if: "!contains(github.event.head_commit.message, '[skip release]')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,6 +26,23 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Bump chart patch versions
+        id: bump
+        run: |
+          ./scripts/bump-chart-patch.sh ${{ github.event.before }} ${{ github.sha }}
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit version bumps
+        if: steps.bump.outputs.changed == 'true'
+        run: |
+          git add charts/**/Chart.yaml
+          git commit -m "Bump chart patch versions [skip release]"
+          git push origin HEAD:${{ github.ref }}
 
       - name: Add MCP chart repository
         run: |

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -13,9 +13,11 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  prepare:
     if: "!contains(github.event.head_commit.message, '[skip release]')"
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.bump.outputs.matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,15 +29,10 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Bump chart patch versions
+      - name: Detect changed charts and bump patch versions
         id: bump
         run: |
           ./scripts/bump-chart-patch.sh ${{ github.event.before }} ${{ github.sha }}
-          if git diff --quiet; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Commit version bumps
         if: steps.bump.outputs.changed == 'true'
@@ -43,6 +40,19 @@ jobs:
           git add charts/**/Chart.yaml
           git commit -m "Bump chart patch versions [skip release]"
           git push origin HEAD:${{ github.ref }}
+
+  release:
+    needs: prepare
+    if: ${{ fromJson(needs.prepare.outputs.matrix).chart != [] }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Add MCP chart repository
         run: |
@@ -52,7 +62,7 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:
-          charts_dir: charts
+          charts_dir: charts/${{ matrix.chart }}
           pages_branch: gh-pages
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -37,10 +37,12 @@ jobs:
 
       - name: Lint all charts
         run: |
+          status=0
           for chart in charts/*; do
             helm dependency update "$chart" || true
-            helm lint "$chart"
+            helm lint "$chart" || status=1
           done
+          exit $status
 
       - name: Install kubeval
         run: |
@@ -50,9 +52,11 @@ jobs:
 
       - name: Render and validate charts
         run: |
+          status=0
           for chart in charts/*; do
-            helm template "$chart" | kubeval - --ignore-missing-schemas
+            helm template "$chart" | kubeval - --ignore-missing-schemas || status=1
           done
+          exit $status
 
       - name: Install yq
         run: |

--- a/scripts/bump-chart-patch.sh
+++ b/scripts/bump-chart-patch.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base=${1:-HEAD~1}
+head=${2:-HEAD}
+
+changed_files=$(git diff --name-only "$base" "$head")
+
+charts_changed=()
+while IFS= read -r file; do
+  if [[ $file =~ ^charts/([^/]+)/ ]]; then
+    chart="${BASH_REMATCH[1]}"
+    if [[ ! " ${charts_changed[*]} " =~ " ${chart} " ]]; then
+      charts_changed+=("$chart")
+    fi
+  fi
+done <<< "$changed_files"
+
+for chart in "${charts_changed[@]:-}"; do
+  chart_yaml="charts/$chart/Chart.yaml"
+  if [[ -f "$chart_yaml" ]]; then
+    current_version=$(grep '^version:' "$chart_yaml" | awk '{print $2}')
+    if [[ -n "$current_version" ]]; then
+      IFS='.' read -r major minor patch <<< "$current_version"
+      patch=$((patch+1))
+      new_version="${major}.${minor}.${patch}"
+      sed -i "s/^version:.*/version: $new_version/" "$chart_yaml"
+      echo "Bumped $chart to version $new_version"
+    fi
+  fi
+done

--- a/scripts/check-artifacthub.sh
+++ b/scripts/check-artifacthub.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 required=(license maintainers)
-for chart in charts/*; do
+
+charts=("${@}")
+if [[ ${#charts[@]} -eq 0 ]]; then
+  charts=(charts/*)
+fi
+
+status=0
+for chart in "${charts[@]}"; do
   chart_yaml="$chart/Chart.yaml"
   if [[ ! -f "$chart_yaml" ]]; then
     echo "Skipping $chart: no Chart.yaml" >&2
@@ -11,8 +19,9 @@ for chart in charts/*; do
     value=$(yq ".${key}" "$chart_yaml")
     if [[ "$value" == "null" ]]; then
       echo "Missing $key in $chart_yaml" >&2
-      exit 1
+      status=1
     fi
   done
   echo "$chart ready"
 done
+exit $status


### PR DESCRIPTION
## Summary
- bump patch versions automatically on release
- skip release workflow for version bump commits

## Testing
- `yamllint .github/workflows/chart-release.yml`
- `./scripts/check-artifacthub.sh`

------
https://chatgpt.com/codex/tasks/task_e_6884e5061b448320a491829e81c01a6d

## Summary by Sourcery

Automate patch version bumping for Helm charts by detecting changed charts and integrating this process into the release workflow, while preventing redundant releases from auto-generated bump commits.

Enhancements:
- Add scripts/bump-chart-patch.sh to detect modified charts and increment their patch versions.

CI:
- Integrate automatic patch version bumping into the chart-release workflow with conditional commit and push steps for version updates.
- Skip the release job for commits containing '[skip release]' to avoid triggering releases from auto-bump commits.