### PR TITLE
Add templated config for mcpo

### DIFF
--- a/charts/mcpo/Chart.yaml
+++ b/charts/mcpo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mcpo/README.md
+++ b/charts/mcpo/README.md
@@ -79,6 +79,26 @@ The command removes all the Kubernetes components associated with the chart and 
 | `envSecrets` | Environment variables from external secrets         | `{}`  |
 | `secretEnv`  | Environment variables to be set from created secret | `{}`  |
 
+### Configuration file
+
+| Name      | Description                                         | Value |
+| --------- | --------------------------------------------------- | ----- |
+| `config`  | Structure used to generate `config.json`            | `see values.yaml` |
+
+Default `config` structure:
+
+```yaml
+mcpServers:
+  memory:
+    command: npx
+    args:
+      - -y
+      - "@modelcontextprotocol/server-memory"
+```
+
+See the commented example in `values.yaml` for a more complete configuration with
+additional MCP servers.
+
 ### Autoscaling parameters
 
 | Name                                            | Description                              | Value |
@@ -91,7 +111,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration and installation details
 
-mcpo proxies another MCP server. Supply the command to run after `--` using `env` or a configuration file mounted as a volume and referenced with `--config`.
+mcpo proxies another MCP server. The chart mounts a `config.json` file from a
+ConfigMap and starts the container with `--config /opt/mcpo/config.json`.
+`config.json` is generated from the `config` values found in `values.yaml`. The
+default configuration defines several MCP servers which can be customized by
+editing the `config` section.
 
 ### Exposing the application
 

--- a/charts/mcpo/templates/_helpers.tpl
+++ b/charts/mcpo/templates/_helpers.tpl
@@ -21,3 +21,8 @@
 {{- define "mcp-mcpo-helm.serviceAccountName" -}}
 {{ include "mcp-library.serviceAccountName" . }}
 {{- end }}
+
+{{/* Render mcpo configuration as pretty JSON */}}
+{{- define "mcp-mcpo-helm.config" -}}
+{{- .Values.config | toPrettyJson }}
+{{- end }}

--- a/charts/mcpo/templates/configmap.yaml
+++ b/charts/mcpo/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-mcpo-helm.fullname" . }}
+  labels:
+    {{- include "mcp-mcpo-helm.labels" . | nindent 4 }}
+data:
+  config.json: |
+    {{- include "mcp-mcpo-helm.config" . | nindent 4 }}

--- a/charts/mcpo/templates/deployment.yaml
+++ b/charts/mcpo/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ or .Values.image.tag .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--config"
+            - "/opt/mcpo/config.json"
           {{- if or .Values.env .Values.envSecrets .Values.secretEnv.data }}
           env:
             {{- range $key, $val := .Values.env }}
@@ -60,6 +63,10 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /opt/mcpo/config.json
+              subPath: config.json
           livenessProbe:
             httpGet:
               path: /
@@ -86,3 +93,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "mcp-mcpo-helm.fullname" . }}

--- a/charts/mcpo/values.yaml
+++ b/charts/mcpo/values.yaml
@@ -94,3 +94,34 @@ envSecrets: {}
 # Secret configuration for sensitive data
 secretEnv:
   data: {}
+
+# Configuration file contents for mcpo. Values will be rendered as JSON in
+# `config.json` and mounted to the container.
+config:
+  mcpServers:
+    memory:
+      command: npx
+      args:
+        - -y
+        - "@modelcontextprotocol/server-memory"
+  # Example of a more complete configuration:
+  # mcpServers:
+  #   memory:
+  #     command: npx
+  #     args:
+  #       - -y
+  #       - "@modelcontextprotocol/server-memory"
+  #   time:
+  #     command: uvx
+  #     args:
+  #       - mcp-server-time
+  #       - --local-timezone=America/New_York
+  #   mcp_sse:
+  #     type: sse
+  #     url: http://127.0.0.1:8001/sse
+  #     headers:
+  #       Authorization: Bearer token
+  #       X-Custom-Header: value
+  #   mcp_streamable_http:
+  #     type: streamable_http
+  #     url: http://127.0.0.1:8002/mcp


### PR DESCRIPTION
## Summary
- bump mcpo chart version to 0.1.6
- minimal config only defines the memory MCP server
- provide commented example of a full configuration
- document new default config in README

## Testing
- `yamllint .` *(warnings only)*
- `markdownlint '**/*.md'`
- `helm dependency update charts/mcpo`
- `helm lint charts/mcpo`
- `helm template charts/mcpo | kubeval - --ignore-missing-schemas`


------
https://chatgpt.com/codex/tasks/task_e_688646c526ac832097059991839870aa