### PR TITLE
Add templates for extra pod settings

### DIFF
--- a/charts/atlassian/Chart.yaml
+++ b/charts/atlassian/Chart.yaml
@@ -23,6 +23,6 @@ version: 0.1.4
 # It is recommended to use it with quotes.
 dependencies:
   - name: mcp-library
-    version: 0.1.2
+    version: 0.1.3
     repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "1.16.0"

--- a/charts/docker-mcp/Chart.yaml
+++ b/charts/docker-mcp/Chart.yaml
@@ -23,6 +23,6 @@ version: 0.1.1
 # It is recommended to use it with quotes.
 dependencies:
   - name: mcp-library
-    version: 0.1.2
+    version: 0.1.3
     repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "latest"

--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -23,6 +23,6 @@ version: 0.1.1
 # It is recommended to use it with quotes.
 dependencies:
   - name: mcp-library
-    version: 0.1.2
+    version: 0.1.3
     repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "latest"

--- a/charts/home-assistant/Chart.yaml
+++ b/charts/home-assistant/Chart.yaml
@@ -23,6 +23,6 @@ version: 0.1.1
 # It is recommended to use it with quotes.
 dependencies:
   - name: mcp-library
-    version: 0.1.2
+    version: 0.1.3
     repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "latest"

--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -23,6 +23,6 @@ version: 0.1.1
 # It is recommended to use it with quotes.
 dependencies:
   - name: mcp-library
-    version: 0.1.2
+    version: 0.1.3
     repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "latest"

--- a/charts/mcp-library/Chart.yaml
+++ b/charts/mcp-library/Chart.yaml
@@ -4,5 +4,5 @@ description: Common helper templates for MCP charts
 maintainers:
   - name: Open WebUI
 type: library
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.0"

--- a/charts/mcp-library/templates/_helpers.tpl
+++ b/charts/mcp-library/templates/_helpers.tpl
@@ -3,6 +3,34 @@
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/* Render a structure as YAML with template interpolation */}}
+{{- define "mcp-library.tplvalues.render" -}}
+{{- $root := index . 0 -}}
+{{- $vals := index . 1 -}}
+{{- tpl (toYaml $vals) $root }}
+{{- end }}
+
+{{/* Extra volumes for pod spec */}}
+{{- define "mcp-library.extraVolumes" -}}
+{{- if .Values.extraVolumes }}
+{{- include "mcp-library.tplvalues.render" (list . .Values.extraVolumes) }}
+{{- end }}
+{{- end }}
+
+{{/* Extra volume mounts for containers */}}
+{{- define "mcp-library.extraVolumeMounts" -}}
+{{- if .Values.extraVolumeMounts }}
+{{- include "mcp-library.tplvalues.render" (list . .Values.extraVolumeMounts) }}
+{{- end }}
+{{- end }}
+
+{{/* Extra environment variables for containers */}}
+{{- define "mcp-library.extraEnvs" -}}
+{{- if .Values.extraEnvs }}
+{{- include "mcp-library.tplvalues.render" (list . .Values.extraEnvs) }}
+{{- end }}
+{{- end }}
+
 {{/* Create a default fully qualified app name. */}}
 {{- define "mcp-library.fullname" -}}
 {{- if .Values.fullnameOverride }}

--- a/charts/mcpo/Chart.yaml
+++ b/charts/mcpo/Chart.yaml
@@ -23,6 +23,6 @@ version: 0.1.6
 # It is recommended to use it with quotes.
 dependencies:
   - name: mcp-library
-    version: 0.1.2
+    version: 0.1.3
     repository: https://arbuzov.github.io/mcp-helm/
 appVersion: "main"


### PR DESCRIPTION
## Summary
- enhance `mcp-library` with templates for generating extraVolumes, extraVolumeMounts and extraEnvs
- bump library chart version
- update application charts to depend on the new version

## Testing
- `yamllint .`
- `markdownlint '**/*.md'`
- `helm lint charts/mcp-library`
- `helm lint charts/mcpo` *(fails: chart directory is missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68865973fd5c83208bd7e323ad729e51

## Summary by Sourcery

Enhance the mcp-library Helm chart with new pod configuration templates and propagate the version bump across application charts

New Features:
- Add tpl helper and templates for injecting extra volumes, volume mounts, and environment variables into pod specs

Build:
- Bump mcp-library chart version to 0.1.3 and update dependent application charts to use the new version