### PR TITLE
Update mcpo port default

### DIFF
--- a/charts/mcpo/Chart.yaml
+++ b/charts/mcpo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mcpo/README.md
+++ b/charts/mcpo/README.md
@@ -59,7 +59,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name           | Description             | Value       |
 | -------------- | ----------------------- | ----------- |
 | `service.type` | mcpo service type       | `ClusterIP` |
-| `service.port` | mcpo service HTTP port  | `8080`      |
+| `service.port` | mcpo service HTTP port  | `8000`      |
 
 ### Ingress parameters
 
@@ -124,7 +124,7 @@ To access the mcpo server from outside the cluster, you can:
 1. **Use port forwarding** (for development):
 
    ```bash
-   kubectl port-forward svc/mcpo 8080:8080
+   kubectl port-forward svc/mcpo 8000:8000
    ```
 
 2. **Enable ingress** (for production):

--- a/charts/mcpo/templates/NOTES.txt
+++ b/charts/mcpo/templates/NOTES.txt
@@ -17,7 +17,7 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mcp-mcpo-helm.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  echo "Visit http://127.0.0.1:{{ default 8000 .Values.service.port }} to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ default 8000 .Values.service.port }}:$CONTAINER_PORT
 {{- end }}
 

--- a/charts/mcpo/templates/deployment.yaml
+++ b/charts/mcpo/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
           args:
             - "--config"
             - "/opt/mcpo/config.json"
+            - "--port"
+            - "{{ default 8000 .Values.service.port }}"
           {{- if or .Values.env .Values.envSecrets .Values.secretEnv.data }}
           env:
             {{- range $key, $val := .Values.env }}

--- a/charts/mcpo/values.yaml
+++ b/charts/mcpo/values.yaml
@@ -38,8 +38,8 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8080
-  targetPort: 8080
+  port: 8000
+  targetPort: 8000
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary
- default mcpo port to 8000
- pass `service.port` to mcpo process via `--port`
- update docs and NOTES with new default port
- bump chart version

## Testing
- `yamllint .`
- `markdownlint '**/*.md'`
- `helm lint` on all charts
- `helm template "$chart" | kubeval - --ignore-missing-schemas` on all charts

------
https://chatgpt.com/codex/tasks/task_e_68865fb139748320b33df68ec5d61f25

## Summary by Sourcery

Update mcpo Helm chart to use port 8000 by default, pass the port value into the mcpo container, update documentation, and bump the chart version.

Enhancements:
- Change default mcpo service HTTP port and targetPort from 8080 to 8000 in values and templates
- Pass service.port into the mcpo process via the --port flag

Build:
- Bump mcpo chart version to 0.1.7

Documentation:
- Update README and NOTES with the new default service port