### PR TITLE
Add configurable ingress path

### DIFF
--- a/charts/atlassian/README.md
+++ b/charts/atlassian/README.md
@@ -21,10 +21,10 @@ A Helm chart for Kubernetes
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
-| ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths[0].path | string | `"/"` |  |
-| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| ingress.path | string | `/` |  |
+| ingress.pathType | string | `ImplementationSpecific` |  |
+| ingress.hosts | list | `["chart-example.local"]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |

--- a/charts/atlassian/templates/deployment.yaml
+++ b/charts/atlassian/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if ne .Values.ingress.path "/" }}
+          args:
+            - --path-prefix={{ .Values.ingress.path }}
+          {{- end }}
           {{- if or .Values.env .Values.envSecrets .Values.secretEnv.data }}
           env:
             {{- range $key, $val := .Values.env }}

--- a/charts/atlassian/templates/ingress.yaml
+++ b/charts/atlassian/templates/ingress.yaml
@@ -37,14 +37,17 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- $ingressPath := "/" }}
+    {{- if ne .Values.ingress.path "/" }}
+    {{- $ingressPath = printf "%s(/|$)(.*)" .Values.ingress.path }}
+    {{- end }}
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ if eq . "*" }}""{{ else }}{{ . | quote }}{{ end }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+          - path: {{ $ingressPath }}
+            {{- if and $.Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $.Values.ingress.pathType }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
@@ -56,6 +59,5 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
-          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/atlassian/values.yaml
+++ b/charts/atlassian/values.yaml
@@ -46,11 +46,10 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  path: /
+  pathType: ImplementationSpecific
   hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
+    - chart-example.local
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/docker-mcp/README.md
+++ b/charts/docker-mcp/README.md
@@ -69,7 +69,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.enabled`     | Enable ingress record generation for MCP          | `false`             |
 | `ingress.className`   | IngressClass that will be be used to implement the Ingress | `""`                |
 | `ingress.annotations` | Additional annotations for the Ingress resource           | `{}`                |
-| `ingress.hosts`       | An array with hosts and paths                             | `[{host: "mcp.local", paths: [{path: "/", pathType: "Prefix"}]}]` |
+| `ingress.path` | Base path for the service | `/` |
+| `ingress.pathType` | Path matching behavior | `Prefix` |
+| `ingress.hosts` | List of hostnames | `["mcp.local"]` |
 | `ingress.tls`         | TLS configuration for ingress                             | `[]`                |
 
 ### Environment variables
@@ -108,11 +110,9 @@ To access the MCP server from outside the cluster, you can:
    ingress:
      enabled: true
      className: "nginx"
+     path: /
      hosts:
-       - host: docker-mcp.your-domain.com
-         paths:
-           - path: /
-             pathType: Prefix
+       - docker-mcp.your-domain.com
    ```
 
 3. **Use LoadBalancer service type**:

--- a/charts/docker-mcp/templates/deployment.yaml
+++ b/charts/docker-mcp/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if ne .Values.ingress.path "/" }}
+          args:
+            - --path-prefix={{ .Values.ingress.path }}
+          {{- end }}
           {{- if or .Values.env .Values.envSecrets .Values.secretEnv.data }}
           env:
             {{- range $key, $val := .Values.env }}

--- a/charts/docker-mcp/templates/ingress.yaml
+++ b/charts/docker-mcp/templates/ingress.yaml
@@ -35,14 +35,17 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- $ingressPath := "/" }}
+    {{- if ne .Values.ingress.path "/" }}
+    {{- $ingressPath = printf "%s(/|$)(.*)" .Values.ingress.path }}
+    {{- end }}
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ if eq . "*" }}""{{ else }}{{ . | quote }}{{ end }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+          - path: {{ $ingressPath }}
+            {{- if and $.Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $.Values.ingress.pathType }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
@@ -54,6 +57,5 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
-          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/docker-mcp/values.yaml
+++ b/charts/docker-mcp/values.yaml
@@ -47,11 +47,10 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  path: /
+  pathType: Prefix
   hosts:
-    - host: mcp.local
-      paths:
-        - path: /
-          pathType: Prefix
+    - mcp.local
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/gitlab/README.md
+++ b/charts/gitlab/README.md
@@ -68,8 +68,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.enabled`     | Enable ingress record generation for GitLab MCP          | `false`             |
 | `ingress.className`   | IngressClass that will be be used to implement the Ingress | `""`                |
 | `ingress.annotations` | Additional annotations for the Ingress resource           | `{}`                |
-| `ingress.hosts`       | An array with hosts and paths                             | `[{host: "gitlab-mcp.local", paths: [{path: "/", pathType: "Prefix"}]}]` |
-| `ingress.tls`         | TLS configuration for ingress                             | `[]`                |
+| `ingress.path` | Base path for the service | `/` |
+| `ingress.pathType` | Path matching behavior | `Prefix` |
+| `ingress.hosts` | List of hostnames | `["gitlab-mcp.local"]` |
+| `ingress.tls`         | TLS configuration for ingress            | `[]`                |
 
 ### Environment variables
 
@@ -129,11 +131,9 @@ To access the GitLab MCP server from outside the cluster, you can:
    ingress:
      enabled: true
      className: "nginx"
+     path: /
      hosts:
-       - host: gitlab-mcp.your-domain.com
-         paths:
-           - path: /
-             pathType: Prefix
+       - gitlab-mcp.your-domain.com
    ```
 
 3. **Use LoadBalancer service type**:

--- a/charts/gitlab/templates/deployment.yaml
+++ b/charts/gitlab/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if ne .Values.ingress.path "/" }}
+          args:
+            - --path-prefix={{ .Values.ingress.path }}
+          {{- end }}
           {{- if or .Values.env .Values.envSecrets .Values.secretEnv.data }}
           env:
             {{- range $key, $val := .Values.env }}

--- a/charts/gitlab/templates/ingress.yaml
+++ b/charts/gitlab/templates/ingress.yaml
@@ -35,14 +35,17 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- $ingressPath := "/" }}
+    {{- if ne .Values.ingress.path "/" }}
+    {{- $ingressPath = printf "%s(/|$)(.*)" .Values.ingress.path }}
+    {{- end }}
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ if eq . "*" }}""{{ else }}{{ . | quote }}{{ end }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+          - path: {{ $ingressPath }}
+            {{- if and $.Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $.Values.ingress.pathType }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
@@ -54,6 +57,5 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
-          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -47,11 +47,10 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  path: /
+  pathType: Prefix
   hosts:
-    - host: gitlab-mcp.local
-      paths:
-        - path: /
-          pathType: Prefix
+    - gitlab-mcp.local
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/home-assistant/README.md
+++ b/charts/home-assistant/README.md
@@ -68,7 +68,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.enabled`     | Enable ingress record generation for Home Assistant MCP          | `false`             |
 | `ingress.className`   | IngressClass that will be be used to implement the Ingress | `""`                |
 | `ingress.annotations` | Additional annotations for the Ingress resource           | `{}`                |
-| `ingress.hosts`       | An array with hosts and paths                             | `[{host: "hass-mcp.local", paths: [{path: "/", pathType: "Prefix"}]}]` |
+| `ingress.path` | Base path for the service | `/` |
+| `ingress.pathType` | Path matching behavior | `Prefix` |
+| `ingress.hosts` | List of hostnames | `["hass-mcp.local"]` |
 | `ingress.tls`         | TLS configuration for ingress                             | `[]`                |
 
 ### Environment variables
@@ -129,11 +131,9 @@ To access the Home Assistant MCP server from outside the cluster, you can:
    ingress:
      enabled: true
      className: "nginx"
+     path: /
      hosts:
-       - host: hass-mcp.your-domain.com
-         paths:
-           - path: /
-             pathType: Prefix
+       - hass-mcp.your-domain.com
    ```
 
 3. **Use LoadBalancer service type**:

--- a/charts/home-assistant/templates/deployment.yaml
+++ b/charts/home-assistant/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if ne .Values.ingress.path "/" }}
+          args:
+            - --path-prefix={{ .Values.ingress.path }}
+          {{- end }}
           {{- if or .Values.env .Values.envSecrets .Values.secretEnv.data }}
           env:
             {{- range $key, $val := .Values.env }}

--- a/charts/home-assistant/templates/ingress.yaml
+++ b/charts/home-assistant/templates/ingress.yaml
@@ -35,14 +35,17 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- $ingressPath := "/" }}
+    {{- if ne .Values.ingress.path "/" }}
+    {{- $ingressPath = printf "%s(/|$)(.*)" .Values.ingress.path }}
+    {{- end }}
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ if eq . "*" }}""{{ else }}{{ . | quote }}{{ end }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+          - path: {{ $ingressPath }}
+            {{- if and $.Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $.Values.ingress.pathType }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
@@ -54,6 +57,5 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
-          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/home-assistant/values.yaml
+++ b/charts/home-assistant/values.yaml
@@ -47,11 +47,10 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  path: /
+  pathType: Prefix
   hosts:
-    - host: hass-mcp.local
-      paths:
-        - path: /
-          pathType: Prefix
+    - hass-mcp.local
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/kubernetes/README.md
+++ b/charts/kubernetes/README.md
@@ -68,7 +68,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.enabled`     | Enable ingress record generation for MCP          | `false`             |
 | `ingress.className`   | IngressClass that will be be used to implement the Ingress | `""`                |
 | `ingress.annotations` | Additional annotations for the Ingress resource           | `{}`                |
-| `ingress.hosts`       | An array with hosts and paths                             | `[{host: "mcp.local", paths: [{path: "/", pathType: "Prefix"}]}]` |
+| `ingress.path` | Base path for the service | `/` |
+| `ingress.pathType` | Path matching behavior | `Prefix` |
+| `ingress.hosts` | List of hostnames | `["mcp.local"]` |
 | `ingress.tls`         | TLS configuration for ingress                             | `[]`                |
 
 ### Environment variables
@@ -107,11 +109,9 @@ To access the MCP server from outside the cluster, you can:
    ingress:
      enabled: true
      className: "nginx"
+     path: /
      hosts:
-       - host: mcp.your-domain.com
-         paths:
-           - path: /
-             pathType: Prefix
+       - mcp.your-domain.com
    ```
 
 3. **Use LoadBalancer service type**:

--- a/charts/kubernetes/templates/deployment.yaml
+++ b/charts/kubernetes/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if ne .Values.ingress.path "/" }}
+          args:
+            - --path-prefix={{ .Values.ingress.path }}
+          {{- end }}
           {{- if or .Values.env .Values.envSecrets .Values.secretEnv.data }}
           env:
             {{- range $key, $val := .Values.env }}

--- a/charts/kubernetes/templates/ingress.yaml
+++ b/charts/kubernetes/templates/ingress.yaml
@@ -35,14 +35,17 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- $ingressPath := "/" }}
+    {{- if ne .Values.ingress.path "/" }}
+    {{- $ingressPath = printf "%s(/|$)(.*)" .Values.ingress.path }}
+    {{- end }}
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ if eq . "*" }}""{{ else }}{{ . | quote }}{{ end }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+          - path: {{ $ingressPath }}
+            {{- if and $.Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $.Values.ingress.pathType }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
@@ -54,6 +57,5 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
-          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/kubernetes/values.yaml
+++ b/charts/kubernetes/values.yaml
@@ -47,11 +47,10 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  path: /
+  pathType: Prefix
   hosts:
-    - host: mcp.local
-      paths:
-        - path: /
-          pathType: Prefix
+    - mcp.local
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/mcpo/README.md
+++ b/charts/mcpo/README.md
@@ -68,7 +68,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.enabled`     | Enable ingress record generation for mcpo                | `false` |
 | `ingress.className`   | IngressClass that will be used to implement the Ingress   | `""`    |
 | `ingress.annotations` | Additional annotations for the Ingress resource          | `{}`    |
-| `ingress.hosts`       | An array with hosts and paths                             | `[{host: "mcpo.local", paths: [{path: "/", pathType: "Prefix"}]}]` |
+| `ingress.path` | Base path for the service | `/` |
+| `ingress.pathType` | Path matching behavior | `Prefix` |
+| `ingress.hosts` | List of hostnames | `["mcpo.local"]` |
 | `ingress.tls`         | TLS configuration for ingress                             | `[]`    |
 
 ### Environment variables
@@ -133,11 +135,9 @@ To access the mcpo server from outside the cluster, you can:
    ingress:
      enabled: true
      className: "nginx"
+     path: /
      hosts:
-       - host: mcpo.your-domain.com
-         paths:
-           - path: /
-             pathType: Prefix
+       - mcpo.your-domain.com
    ```
 
 3. **Use LoadBalancer service type**:

--- a/charts/mcpo/templates/deployment.yaml
+++ b/charts/mcpo/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
             - "/opt/mcpo/config.json"
             - "--port"
             - "{{ default 8000 .Values.service.port }}"
+            {{- if ne .Values.ingress.path "/" }}
+            - "--path-prefix={{ .Values.ingress.path }}"
+            {{- end }}
           {{- if or .Values.env .Values.envSecrets .Values.secretEnv.data }}
           env:
             {{- range $key, $val := .Values.env }}

--- a/charts/mcpo/templates/ingress.yaml
+++ b/charts/mcpo/templates/ingress.yaml
@@ -35,14 +35,17 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+    {{- $ingressPath := "/" }}
+    {{- if ne .Values.ingress.path "/" }}
+    {{- $ingressPath = printf "%s(/|$)(.*)" .Values.ingress.path }}
+    {{- end }}
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ if eq . "*" }}""{{ else }}{{ . | quote }}{{ end }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
-            pathType: {{ .pathType }}
+          - path: {{ $ingressPath }}
+            {{- if and $.Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.Version) }}
+            pathType: {{ $.Values.ingress.pathType }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
@@ -54,6 +57,5 @@ spec:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
               {{- end }}
-          {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/mcpo/values.yaml
+++ b/charts/mcpo/values.yaml
@@ -47,11 +47,10 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  path: /
+  pathType: Prefix
   hosts:
-    - host: mcpo.local
-      paths:
-        - path: /
-          pathType: Prefix
+    - mcpo.local
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
## Summary
- allow configuring `ingress.path`
- pass `--path-prefix` argument when path is not `/`
- update ingress templates and READMEs

## Testing
- `yamllint charts`
- `markdownlint '**/*.md'` *(fails: README.md MD012 MD040)*
- `for c in charts/*; do helm dependency update "$c" >/dev/null || true; helm lint "$c"; done`
- `for c in charts/*; do helm template "$c" | kubeval - --ignore-missing-schemas; done`

------
https://chatgpt.com/codex/tasks/task_e_688687b6d754832090618f4123036b2a