### PR TITLE
Add library version output

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -41,6 +41,9 @@ jobs:
           skip_existing: false
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Show released library version
+        run: echo "Released mcp-library version ${{ steps.cr.outputs.chart_version }}"
   release_all:
     needs: release_library
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- output mcp-library version in the release job for debugging

## Testing
- `helm lint` on all charts

------
https://chatgpt.com/codex/tasks/task_e_68869acd64cc8320aa48b0bfb264c540

## Summary by Sourcery

CI:
- Add a "Show released library version" step that echoes the released mcp-library chart_version for debugging purposes