### PR TITLE
Fix default port for mcp-atlassian

### DIFF
--- a/charts/atlassian/README.md
+++ b/charts/atlassian/README.md
@@ -32,7 +32,7 @@ A Helm chart for Kubernetes
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
-| service.port | int | `80` |  |
+| service.port | int | `8000` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/atlassian/templates/deployment.yaml
+++ b/charts/atlassian/templates/deployment.yaml
@@ -66,11 +66,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /sse
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /sse
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/atlassian/values.yaml
+++ b/charts/atlassian/values.yaml
@@ -38,7 +38,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8000
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary
- update default service port for atlassian chart
- set default liveness and readiness probe path to `/sse`

## Testing
- `yamllint .`
- `markdownlint '**/*.md'`
- `helm dependency update "$chart"` and `helm lint "$chart"` for all charts
- `helm template "$chart" | kubeval - --ignore-missing-schemas` for all charts

------
https://chatgpt.com/codex/tasks/task_e_688a88e750548320a4676e365d0bf6c2