### PR TITLE
Add sidecar support to mcp-atlassian

### DIFF
--- a/charts/atlassian/Chart.yaml
+++ b/charts/atlassian/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/atlassian/README.md
+++ b/charts/atlassian/README.md
@@ -1,6 +1,6 @@
 # mcp-atlassian-helm
 
-![version: 0.2.4](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![version: 0.2.5](https://img.shields.io/badge/Version-0.2.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -41,5 +41,6 @@ A Helm chart for Kubernetes
 | env | object | `{}` | Extra environment variables |
 | envSecrets | object | `{}` | Environment variables from secrets |
 | secretEnv | object | `{}` | Create secret with environment data; keys must be valid secret keys and values cannot be empty |
+| sidecars | list | `[]` | Additional sidecar containers |
 
 When `ingress.path` is not `/`, the annotation `nginx.ingress.kubernetes.io/use-regex: "true"` is automatically added.

--- a/charts/atlassian/templates/deployment.yaml
+++ b/charts/atlassian/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.sidecars }}
+      {{- include "mcp-library.tplvalues.render" (list . .Values.sidecars) | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/atlassian/values.yaml
+++ b/charts/atlassian/values.yaml
@@ -103,3 +103,11 @@ envSecrets: {}
 #     CONFLUENCE_API_TOKEN: your_conf_token
 # Keys must be valid Kubernetes secret keys (RFC 1123) and values cannot be empty.
 secretEnv: {}
+
+# Additional sidecar containers to run alongside the main container.
+# Example:
+# sidecars:
+#   - name: sidecar
+#     image: busybox
+#     command: ["sh", "-c", "echo sidecar && sleep 3600"]
+sidecars: []

--- a/charts/atlassian/values.yaml
+++ b/charts/atlassian/values.yaml
@@ -105,6 +105,9 @@ envSecrets: {}
 secretEnv: {}
 
 # Additional sidecar containers to run alongside the main container.
+# Each list item must include `name` and `image` and may specify any other
+# fields allowed in the Kubernetes `Container` spec such as `command`, `args`,
+# `env`, `ports`, or `volumeMounts`.
 # Example:
 # sidecars:
 #   - name: sidecar


### PR DESCRIPTION
## Summary
- allow sidecar containers in `mcp-atlassian` deployment via new `sidecars` value
- document the new option and bump chart version

## Testing
- `yamllint .`
- `markdownlint '**/*.md'`
- `for chart in charts/*; do helm lint "$chart"; done`
- `for chart in charts/*; do helm template "$chart" | kubeval - --ignore-missing-schemas; done`


------
https://chatgpt.com/codex/tasks/task_e_688a8fcfe0d88320a3e0a5819faf2e78

## Summary by Sourcery

Add support for custom sidecar containers to the mcp-atlassian Helm chart, update documentation, and bump chart version

New Features:
- Enable additional sidecar containers in the mcp-atlassian deployment via a new sidecars values field

Enhancements:
- Render provided sidecars in the deployment template when the sidecars list is non-empty

Build:
- Bump mcp-atlassian chart version to 0.2.5

Documentation:
- Document the sidecars option in the chart README and values schema