### PR TITLE
Fix NOTES template for simple ingress hosts

### DIFF
--- a/charts/gitlab/templates/NOTES.txt
+++ b/charts/gitlab/templates/NOTES.txt
@@ -1,8 +1,17 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- if kindIs "string" $host }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ $.Values.ingress.path }}
+  {{- else }}
+    {{- $hostName := default "" $host.host }}
+    {{- if $host.paths }}
+      {{- range $path := $host.paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $hostName }}{{ $path.path }}
+      {{- end }}
+    {{- else }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $hostName }}{{ $.Values.ingress.path }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}


### PR DESCRIPTION
## Summary
- update the NOTES helper to handle string-style ingress host entries without paths
- fall back to the chart's configured ingress path when custom paths are not provided

## Testing
- no tests were run (helm CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cdab5dde6083209c82679e57529b51

## Summary by Sourcery

Improve Helm chart NOTES helper to support simplistic ingress host definitions and use the chart's default path when no custom path is provided

Enhancements:
- Add support for string-style ingress host entries in the NOTES template
- Fallback to the chart-configured ingress path when custom paths are omitted