### PR TITLE
fix(gitlab): update service port to 3002 and adjust health probe conf…

### DIFF
--- a/charts/atlassian/Chart.yaml
+++ b/charts/atlassian/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mcp-atlassian
 description: A Helm chart for Kubernetes
-icon: https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/atlassian.svg
+icon: https://raw.githubusercontent.com/modelcontextprotocol/docs/main/logo/light.svg
 
 # A chart can be either an "application" or a "library" chart.
 #

--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: mcp-gitlab
 description: A Helm chart for deploying GitLab MCP server
+icon: https://raw.githubusercontent.com/modelcontextprotocol/docs/main/logo/light.svg
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -18,7 +19,7 @@ type: application
 # each time you make changes to the chart and its templates, including
 # the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This
 # version number should be incremented each time you make changes to the

--- a/charts/gitlab/README.md
+++ b/charts/gitlab/README.md
@@ -59,26 +59,26 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name           | Description                        | Value       |
 | -------------- | ---------------------------------- | ----------- |
 | `service.type` | GitLab MCP service type            | `ClusterIP` |
-| `service.port` | GitLab MCP service HTTP port       | `8080`      |
+| `service.port` | GitLab MCP service HTTP port       | `3002`      |
 
 ### Health probe parameters
 
 | Name                                  | Description                                                       | Value |
 | ------------------------------------- | ----------------------------------------------------------------- | ----- |
 | `livenessProbe.enabled`               | Enable liveness probe                                             | `true` |
-| `livenessProbe.port`                  | Port used by the liveness probe                                   | `3002` |
+| `livenessProbe.port`                  | Port used by the liveness probe                                   | `nil`  |
 | `livenessProbe.initialDelaySeconds`   | Delay before the liveness probe starts                            | `60`   |
 | `livenessProbe.periodSeconds`         | Frequency of the liveness probe                                   | `30`   |
 | `livenessProbe.timeoutSeconds`        | Timeout for the liveness probe                                    | `10`   |
 | `livenessProbe.failureThreshold`      | Number of consecutive failures before marking the pod as unhealthy | `3`    |
 | `readinessProbe.enabled`              | Enable readiness probe                                             | `true` |
-| `readinessProbe.port`                 | Port used by the readiness probe                                  | `3002` |
+| `readinessProbe.port`                 | Port used by the readiness probe                                  | `nil`  |
 | `readinessProbe.initialDelaySeconds`  | Delay before the readiness probe starts                           | `15`   |
 | `readinessProbe.periodSeconds`        | Frequency of the readiness probe                                  | `10`   |
 | `readinessProbe.timeoutSeconds`       | Timeout for the readiness probe                                   | `10`   |
 | `readinessProbe.failureThreshold`     | Number of consecutive failures before marking the pod as unready  | `3`    |
 
-Both probes use the `/health` endpoint by default.
+Both probes use the `/health` endpoint by default and inherit `service.port`.
 
 ### Ingress parameters
 

--- a/charts/gitlab/templates/deployment.yaml
+++ b/charts/gitlab/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         {{- include "mcp-gitlab-helm.selectorLabels" . | nindent 8 }}
     spec:
+      {{- $servicePort := default 3002 .Values.service.port }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -62,25 +63,23 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.targetPort }}
+              containerPort: {{ $servicePort }}
               protocol: TCP
-          {{- $livenessPort := default 3002 .Values.livenessProbe.port }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: "/health"
-              port: {{ $livenessPort }}
+              port: {{ $servicePort }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           {{- end }}
-          {{- $readinessPort := default 3002 .Values.readinessProbe.port }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: "/health"
-              port: {{ $readinessPort }}
+              port: {{ $servicePort }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -38,14 +38,11 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8080
-  targetPort: 8080
+  port: 3002
 
 # Health check probes configuration
 livenessProbe:
   enabled: true
-  # Override the port used by the liveness probe. Defaults to 3002.
-  port: 3002
   initialDelaySeconds: 60
   periodSeconds: 30
   timeoutSeconds: 10
@@ -53,8 +50,6 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  # Override the port used by the readiness probe. Defaults to 3002.
-  port: 3002
   initialDelaySeconds: 15
   periodSeconds: 10
   timeoutSeconds: 10

--- a/charts/homeassistant/Chart.yaml
+++ b/charts/homeassistant/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: mcp-homeassistant
 description: A Helm chart for deploying Home Assistant MCP server
+icon: https://raw.githubusercontent.com/modelcontextprotocol/docs/main/logo/light.svg
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/kubernetes/Chart.yaml
+++ b/charts/kubernetes/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: mcp-kubernetes
 description: A Helm chart for deploying the MCP server
+icon: https://raw.githubusercontent.com/modelcontextprotocol/docs/main/logo/light.svg
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/mcp-library/Chart.yaml
+++ b/charts/mcp-library/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: mcp-library
 description: Common helper templates for MCP charts
+icon: https://raw.githubusercontent.com/modelcontextprotocol/docs/main/logo/light.svg
 maintainers:
   - name: Open WebUI
 type: library

--- a/charts/mcpo/Chart.yaml
+++ b/charts/mcpo/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: mcpo
 description: A Helm chart for deploying the mcpo proxy server
+icon: https://raw.githubusercontent.com/modelcontextprotocol/docs/main/logo/light.svg
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/search/Chart.yaml
+++ b/charts/search/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: search
 description: >-
   Deploys the MCP search crawler together with FlareSolverr support services.
+icon: https://raw.githubusercontent.com/modelcontextprotocol/docs/main/logo/light.svg
 type: application
 version: 0.1.2
 appVersion: "latest"


### PR DESCRIPTION
…igurations

## Summary by Sourcery

Update GitLab Helm chart default HTTP port to 3002 and simplify health probe port configuration

Bug Fixes:
- Align container port, livenessProbe, and readinessProbe to use service.port defaulting to 3002
- Remove separate livenessProbe.port and readinessProbe.port values from the chart templates and values

Documentation:
- Update README and values.yaml to reflect the new default service.port of 3002 and document that probes inherit service.port when left nil

Chores:
- Bump chart version to 0.3.1