### PR TITLE
fix: use real images for search chart

### DIFF
--- a/charts/search/Chart.yaml
+++ b/charts/search/Chart.yaml
@@ -4,7 +4,7 @@ description: >-
   Deploys the MCP search crawler together with FlareSolverr support services.
 icon: https://raw.githubusercontent.com/modelcontextprotocol/docs/main/logo/light.svg
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "latest"
 keywords:
   - search

--- a/charts/search/README.md
+++ b/charts/search/README.md
@@ -31,10 +31,10 @@ helm install search ./charts/search \
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `replicaCount` | Number of crawler pods to run. | `1` |
-| `crawler.image.repository` | Container image for the crawler service. | `your-docker-repo/search-crawler` |
+| `crawler.image.repository` | Container image for the crawler service. | `ghcr.io/modelcontextprotocol/search-crawler` |
 | `crawler.service.port` | Container port exposed by the crawler. | `8080` |
 | `crawler.env` | Key/value environment variables for the crawler container. | `{}` |
-| `flaresolverr.image.repository` | Container image for FlareSolverr. | `your-docker-repo/flaresolverr` |
+| `flaresolverr.image.repository` | Container image for FlareSolverr. | `ghcr.io/flaresolverr/flaresolverr` |
 | `flaresolverr.service.port` | Container port exposed by FlareSolverr. | `8191` |
 | `service.type` | Kubernetes service type for external access. | `ClusterIP` |
 | `service.port` | Service port forwarded to the crawler container. | `80` |

--- a/charts/search/values.yaml
+++ b/charts/search/values.yaml
@@ -16,7 +16,7 @@ serviceAccount:
 
 crawler:
   image:
-    repository: your-docker-repo/search-crawler
+    repository: ghcr.io/modelcontextprotocol/search-crawler
     tag: latest
     pullPolicy: IfNotPresent
   service:
@@ -27,7 +27,7 @@ crawler:
 
 flaresolverr:
   image:
-    repository: your-docker-repo/flaresolverr
+    repository: ghcr.io/flaresolverr/flaresolverr
     tag: latest
     pullPolicy: IfNotPresent
   service:


### PR DESCRIPTION
## Summary
- point the search crawler to ghcr.io/modelcontextprotocol/search-crawler
- default FlareSolverr to ghcr.io/flaresolverr/flaresolverr
- bump the chart patch version to publish the change

## Testing
- helm lint charts/search *(fails: command not found helm)*

------
https://chatgpt.com/codex/tasks/task_e_68cf335651608320b7c1a36c9dd23085

## Summary by Sourcery

Point search chart to official ghcr.io images for the crawler and FlareSolverr and bump the Helm chart version

Enhancements:
- Update default image repositories to ghcr.io/modelcontextprotocol/search-crawler and ghcr.io/flaresolverr/flaresolverr

Chores:
- Bump Helm chart version to 0.1.3