### PR TITLE
fix: pin gitlab chart image tag

### DIFF
--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # each time you make changes to the chart and its templates, including
 # the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This
 # version number should be incremented each time you make changes to the
@@ -30,4 +30,4 @@ dependencies:
   - name: mcp-library
     version: 0.1.4
     repository: https://arbuzov.github.io/mcp-helm/
-appVersion: "latest"
+appVersion: "2.0.6"

--- a/charts/gitlab/README.md
+++ b/charts/gitlab/README.md
@@ -42,7 +42,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                | Description                                          | Value                    |
 | ------------------- | ---------------------------------------------------- | ------------------------ |
 | `image.repository`  | GitLab MCP image repository                          | `iwakitakuma/gitlab-mcp` |
-| `image.tag`         | GitLab MCP image tag (immutable tags are recommended) | `latest`                 |
+| `image.tag`         | GitLab MCP image tag (immutable tags are recommended) | `2.0.6`                  |
 | `image.pullPolicy`  | GitLab MCP image pull policy                         | `IfNotPresent`           |
 | `imagePullSecrets`  | GitLab MCP image pull secrets                        | `[]`                     |
 

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: iwakitakuma/gitlab-mcp
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: "2.0.6"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary
- pin the GitLab MCP chart to the published 2.0.6 container image
- bump the chart and application versions to 0.3.2/2.0.6 and update documentation defaults

## Testing
- helm lint charts/gitlab *(fails: helm not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e76b2ab3e48320af64c0bd1bea35eb

## Summary by Sourcery

Pin the GitLab MCP chart image tag to a specific version and update chart versions and documentation defaults.

Bug Fixes:
- Pin the GitLab MCP image tag to 2.0.6 instead of latest

Enhancements:
- Bump chart version to 0.3.2 and application appVersion to 2.0.6

Documentation:
- Update README defaults to reflect the new pinned image tag