### PR TITLE
atlassian: Fix envSecret rendering in the deployment

### DIFF
--- a/charts/atlassian/templates/deployment.yaml
+++ b/charts/atlassian/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: {{ $key }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ default (printf "%s-env" (include "mcp-atlassian-helm.fullname" $)) .Values.secretEnv.name }}
+                  name: {{ default (printf "%s-env" (include "mcp-atlassian-helm.fullname" $)) $.Values.secretEnv.name }}
                   key: {{ $key }}
             {{- end }}
             {{- end }}


### PR DESCRIPTION
Fixes #38

## Summary by Sourcery

Bug Fixes:
- Use the correct context reference for secretEnv.name in the secretKeyRef name to ensure envSecret rendering works as intended.