### PR TITLE
feat(mcpo-chart): add option to add custom labels to pods

### DIFF
--- a/charts/mcpo/Chart.yaml
+++ b/charts/mcpo/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mcpo/templates/deployment.yaml
+++ b/charts/mcpo/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         {{- end }}
       labels:
         {{- include "mcp-mcpo-helm.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/mcpo/values.yaml
+++ b/charts/mcpo/values.yaml
@@ -24,6 +24,7 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
+podLabels: {}
 
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
This MR adds the option to add custom labels to the pod of the mcpo chart. For some environments this is very helpful.

## Summary by Sourcery

Allow users to specify custom pod labels in the mcpo Helm chart and update the chart version accordingly

New Features:
- Enable adding custom labels to mcpo chart pods via the podLabels values field

Enhancements:
- Bump mcpo chart version to 0.2.6