### PR TITLE
Update GitLab MCP chart to use multi-arch image

### DIFF
--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -19,7 +19,7 @@ type: application
 # each time you make changes to the chart and its templates, including
 # the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 
 # This is the version number of the application being deployed. This
 # version number should be incremented each time you make changes to the
@@ -30,4 +30,4 @@ dependencies:
   - name: mcp-library
     version: 0.1.4
     repository: https://arbuzov.github.io/mcp-helm/
-appVersion: "2.0.6"
+appVersion: "2.0.7"

--- a/charts/gitlab/README.md
+++ b/charts/gitlab/README.md
@@ -42,7 +42,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                | Description                                          | Value                    |
 | ------------------- | ---------------------------------------------------- | ------------------------ |
 | `image.repository`  | GitLab MCP image repository                          | `iwakitakuma/gitlab-mcp` |
-| `image.tag`         | GitLab MCP image tag (immutable tags are recommended) | `2.0.6`                  |
+| `image.tag`         | GitLab MCP image tag (immutable tags are recommended) | `2.0.7`                  |
 | `image.pullPolicy`  | GitLab MCP image pull policy                         | `IfNotPresent`           |
 | `imagePullSecrets`  | GitLab MCP image pull secrets                        | `[]`                     |
 

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: iwakitakuma/gitlab-mcp
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.0.6"
+  tag: "2.0.7"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary
- bump the GitLab MCP chart version and default app version to 2.0.7
- update the default image tag to 2.0.7 which provides linux/amd64 support
- refresh README defaults to reflect the new container tag

## Testing
- helm lint charts/gitlab *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68f50206859483209dfa172e0e136824

## Summary by Sourcery

Update GitLab MCP helm chart to use the multi-arch 2.0.7 image and bump chart version

Enhancements:
- Bump chart version to 0.3.3
- Update appVersion to 2.0.7
- Refresh default image.tag in values.yaml to 2.0.7

Documentation:
- Update README default image tag to 2.0.7