### PR TITLE
Update search chart crawler image repository

### DIFF
--- a/charts/search/README.md
+++ b/charts/search/README.md
@@ -31,7 +31,7 @@ helm install search ./charts/search \
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `replicaCount` | Number of crawler pods to run. | `1` |
-| `crawler.image.repository` | Container image for the crawler service. | `ghcr.io/modelcontextprotocol/search-crawler` |
+| `crawler.image.repository` | Container image for the crawler service. | `ghcr.io/modelcontextprotocol/search` |
 | `crawler.service.port` | Container port exposed by the crawler. | `8080` |
 | `crawler.env` | Key/value environment variables for the crawler container. | `{}` |
 | `flaresolverr.image.repository` | Container image for FlareSolverr. | `ghcr.io/flaresolverr/flaresolverr` |

--- a/charts/search/values.yaml
+++ b/charts/search/values.yaml
@@ -16,7 +16,7 @@ serviceAccount:
 
 crawler:
   image:
-    repository: ghcr.io/modelcontextprotocol/search-crawler
+    repository: ghcr.io/modelcontextprotocol/search
     tag: latest
     pullPolicy: IfNotPresent
   service:


### PR DESCRIPTION
## Summary
- point the search chart crawler image to the public ghcr.io/modelcontextprotocol/search repository
- update the documentation to reflect the new default image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5e12661148320a354ed05e4dc3875

## Summary by Sourcery

Point the search Helm chart crawler image to the public ghcr.io/modelcontextprotocol/search repository and update related documentation

Enhancements:
- Update default crawler image repository to ghcr.io/modelcontextprotocol/search
- Update Helm chart documentation to reflect new default image repository