### PR TITLE
Handle string ingress hosts in NOTES rendering

### DIFF
--- a/charts/kubernetes/templates/NOTES.txt
+++ b/charts/kubernetes/templates/NOTES.txt
@@ -1,8 +1,16 @@
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
+{{- $ingressPath := include "mcp-library.ingressPath" . }}
 {{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- if kindIs "map" $host }}
+    {{- $hostName := $host.host | default "" }}
+    {{- range $path := $host.paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $hostName }}{{ $path.path | default $ingressPath }}
+    {{- end }}
+  {{- else if eq (toString $host) "*" }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://<ingress-host>{{ $ingressPath }}
+  {{- else }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ $ingressPath }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}


### PR DESCRIPTION
## Summary
- update the NOTES helper to derive the ingress path once
- support both map-based and string-based ingress host definitions when rendering URLs
- fall back to a placeholder when wildcard hosts are used to avoid template failures

## Testing
- not run (helm not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f86ac060832081da3fca68eca183)

## Summary by Sourcery

Improve Helm NOTES template to reliably render ingress URLs from various host configurations and handle wildcard hosts gracefully.

Enhancements:
- Derive the ingress path once in the NOTES helper to avoid repetition
- Support both map-based and string-based ingress host definitions when rendering URLs
- Fallback to a placeholder for wildcard hosts to prevent template failures