### PR TITLE
rebase

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,2 +1,3 @@
 default: true
 MD013: false
+MD060: false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains Helm charts used by the MCP project. All charts are sto
 ## Available charts
 
 - **atlassian** – Helm chart moved from the repository root to `charts/atlassian`. See [its README](charts/atlassian/README.md) for details.
+- **claude-code-api** – Helm chart for the Claude Code OpenAI-compatible gateway. See [its README](charts/claude-code-api/README.md) for usage information.
 - **gitlab** – Helm chart for the GitLab MCP server. See [its README](charts/gitlab/README.md) for usage information.
 - **kubernetes** – Helm chart for running the MCP server locally. See [its README](charts/kubernetes/README.md) for details.
 - **homeassistant** – Helm chart for deploying the Home Assistant MCP server. See [its README](charts/homeassistant/README.md).

--- a/charts/claude-code-api/Chart.yaml
+++ b/charts/claude-code-api/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: claude-code-api
+description: A Helm chart for deploying the Claude Code OpenAI-compatible API gateway
+icon: https://raw.githubusercontent.com/modelcontextprotocol/docs/main/logo/light.svg
+
+type: application
+
+version: 0.1.0
+dependencies:
+  - name: mcp-library
+    version: 0.1.4
+    repository: https://arbuzov.github.io/mcp-helm/
+appVersion: "0.1.0"

--- a/charts/claude-code-api/README.md
+++ b/charts/claude-code-api/README.md
@@ -1,0 +1,143 @@
+# Claude Code API Helm Chart
+
+This Helm chart deploys the [Claude Code API gateway](https://github.com/cabinlab/claude-code-api), an OpenAI-compatible interface for Claude Code with built-in admin UI for exchanging OAuth tokens for API keys.
+
+## Prerequisites
+
+- Kubernetes 1.26+
+- Helm 3.12+
+
+## Installing the Chart
+
+To install the chart with the release name `claude-code-api`:
+
+```bash
+helm install claude-code-api ./charts/claude-code-api \
+  --set "auth.claudeOAuthToken.value=sk-ant-oat01-..." \
+  --set "auth.adminPassword.value=super-secret"
+```
+
+The command deploys the API gateway and stores the provided credentials in a managed Kubernetes secret. See [Parameters](#parameters) for the full list of configurable options.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `claude-code-api` deployment:
+
+```bash
+helm delete claude-code-api
+```
+
+## Parameters
+
+### Global parameters
+
+| Name | Description | Value |
+| --- | --- | --- |
+| `replicaCount` | Number of replicas to deploy | `1` |
+| `nameOverride` | String to partially override `claude-code-api.fullname` | `""` |
+| `fullnameOverride` | String to fully override `claude-code-api.fullname` | `""` |
+
+### Image parameters
+
+| Name | Description | Value |
+| --- | --- | --- |
+| `image.repository` | Container image repository | `ghcr.io/cabinlab/claude-code-api` |
+| `image.tag` | Container image tag (defaults to chart `appVersion` when empty) | `""` |
+| `image.pullPolicy` | Container image pull policy | `IfNotPresent` |
+| `imagePullSecrets` | Kubernetes image pull secrets | `[]` |
+
+### Service account parameters
+
+| Name | Description | Value |
+| --- | --- | --- |
+| `serviceAccount.create` | Specifies whether a service account should be created | `true` |
+| `serviceAccount.annotations` | Annotations to add to the service account | `{}` |
+| `serviceAccount.name` | Name of the service account to use | `""` |
+
+### Service parameters
+
+| Name | Description | Value |
+| --- | --- | --- |
+| `service.type` | Kubernetes service type | `ClusterIP` |
+| `service.ports.http.port` | Service port for the HTTP API | `8000` |
+| `service.ports.http.targetPort` | Container port for the HTTP API | `8000` |
+| `service.ports.https.enabled` | Expose the HTTPS admin port through the service | `true` |
+| `service.ports.https.port` | Service port for the HTTPS admin UI | `8443` |
+| `service.ports.https.targetPort` | Container port for the HTTPS admin UI | `8443` |
+
+### Ingress parameters
+
+| Name | Description | Value |
+| --- | --- | --- |
+| `ingress.enabled` | Enable ingress resource | `false` |
+| `ingress.className` | IngressClass used to implement the Ingress | `""` |
+| `ingress.annotations` | Additional annotations for the Ingress | `{}` |
+| `ingress.path` | Base path for the ingress | `/` |
+| `ingress.pathType` | Path matching behavior | `Prefix` |
+| `ingress.hosts` | Hostnames for the ingress | `["claude-code-api.local"]` |
+| `ingress.tls` | TLS configuration | `[]` |
+
+### Application parameters
+
+| Name | Description | Value |
+| --- | --- | --- |
+| `app.port` | HTTP API port inside the container | `8000` |
+| `app.httpsPort` | HTTPS admin port inside the container | `8443` |
+| `app.nodeEnv` | `NODE_ENV` value for the service | `production` |
+| `app.logLevel` | `LOG_LEVEL` value for the service | `info` |
+
+### Authentication parameters
+
+| Name | Description | Value |
+| --- | --- | --- |
+| `auth.secret.create` | Create and manage a Kubernetes secret for credentials | `false` |
+| `auth.secret.name` | Override name for the managed secret | `""` |
+| `auth.secret.annotations` | Extra annotations for the managed secret | `{}` |
+| `auth.adminPassword.key` | Environment variable key for the admin password | `ADMIN_PASSWORD` |
+| `auth.adminPassword.value` | **Plaintext** admin password stored in the managed secret | `""` |
+| `auth.adminPassword.valueBase64` | Base64-encoded admin password stored verbatim in the managed secret | `""` |
+| `auth.adminPassword.existingSecret` | Existing secret to read the admin password from | `claude-code-api-auth` |
+| `auth.adminPassword.existingSecretKey` | Key inside the existing admin secret | `ADMIN_PASSWORD` |
+| `auth.claudeOAuthToken.key` | Environment variable key for the Claude OAuth token | `CLAUDE_CODE_OAUTH_TOKEN` |
+| `auth.claudeOAuthToken.value` | **Plaintext** Claude OAuth token stored in the managed secret | `""` |
+| `auth.claudeOAuthToken.valueBase64` | Base64-encoded Claude OAuth token stored verbatim in the managed secret | `""` |
+| `auth.claudeOAuthToken.existingSecret` | Existing secret to read the Claude OAuth token from | `claude-code-api-auth` |
+| `auth.claudeOAuthToken.existingSecretKey` | Key inside the existing Claude OAuth secret | `CLAUDE_CODE_OAUTH_TOKEN` |
+
+### Environment parameters
+
+| Name | Description | Value |
+| --- | --- | --- |
+| `env` | Additional environment variables for the container | `{}` |
+| `envSecrets` | Environment variables sourced from external secrets | `{}` |
+| `secretEnv.data` | Additional key/value pairs stored in a dedicated secret and exposed as environment variables | `{}` |
+
+### Autoscaling parameters
+
+| Name | Description | Value |
+| --- | --- | --- |
+| `autoscaling.enabled` | Enable Horizontal Pod Autoscaler | `false` |
+| `autoscaling.minReplicas` | Minimum number of replicas | `1` |
+| `autoscaling.maxReplicas` | Maximum number of replicas | `100` |
+| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage | `80` |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization percentage | `""` |
+
+### Resource parameters
+
+| Name | Description | Value |
+| --- | --- | --- |
+| `resources` | Resource requests and limits for the pod | `{}` |
+
+## Configuration and installation details
+
+### Providing the Claude OAuth token and admin password
+
+The service requires both an admin password for the management UI and a Claude OAuth token used to generate client API keys. Provide these values via `auth.*` settings. By default, the chart expects an existing secret named `claude-code-api-auth` that contains both credentials. To have the chart manage this secret instead, set `auth.secret.create=true` and supply the values for `auth.adminPassword.*` and `auth.claudeOAuthToken.*`.
+
+When the chart manages the secret, `auth.adminPassword.value` (or `valueBase64`) **must** be set to a non-empty value; the template rendering fails otherwise. If you point to existing secrets, you must also set `auth.adminPassword.existingSecretKey` and `auth.claudeOAuthToken.existingSecretKey` so the chart reads the correct keys.
+
+When setting `*.value`, supply the **plaintext** credential; the chart encodes it before writing to the Kubernetes Secret. To supply a pre-encoded value, use the corresponding `*.valueBase64` setting instead.
+
+### Exposing the service
+
+Enable ingress by setting `ingress.enabled=true` and configure `ingress.hosts` and TLS as needed. The service listens on port `8000` for the OpenAI-compatible API and `8443` for the admin UI.

--- a/charts/claude-code-api/templates/NOTES.txt
+++ b/charts/claude-code-api/templates/NOTES.txt
@@ -1,0 +1,41 @@
+Thank you for installing the Claude Code API chart!
+
+1. Check the release status and pod readiness:
+   helm status {{ .Release.Name }}
+   kubectl get pods -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+2. Access the OpenAI-compatible endpoint exposed by the deployment:
+{{- $path := include "mcp-library.ingressPath" . }}
+{{- if .Values.ingress.enabled }}
+   The ingress controller will route external traffic to the service. Once the ingress
+   resource is ready, connect using:
+{{- $scheme := ternary "https" "http" (gt (len .Values.ingress.tls) 0) }}
+{{- range .Values.ingress.hosts }}
+{{- if eq . "*" }}
+   - {{ $scheme }}://<your-hostname>{{ $path }}
+{{- else }}
+   - {{ $scheme }}://{{ . }}{{ $path }}
+{{- end }}
+{{- end }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
+   It may take a few minutes for the LoadBalancer IP to be available.
+   You can watch the status of the service by running:
+     kubectl get svc -n {{ .Release.Namespace }} -w {{ include "claude-code-api-helm.fullname" . }}
+   Once assigned, the endpoint will be:
+     http://$(kubectl get svc -n {{ .Release.Namespace }} {{ include "claude-code-api-helm.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}{.status.loadBalancer.ingress[0].hostname}'):{{ .Values.service.ports.http.port }}{{ $path }}
+{{- else if contains "NodePort" .Values.service.type }}
+   The service is exposed on each node:
+     NODE_PORT=$(kubectl get svc -n {{ .Release.Namespace }} {{ include "claude-code-api-helm.fullname" . }} -o jsonpath='{.spec.ports[0].nodePort}')
+     NODE_IP=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+     echo http://$NODE_IP:$NODE_PORT{{ $path }}
+{{- else }}
+   Port-forward the service for local access:
+     kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "claude-code-api-helm.fullname" . }} {{ .Values.service.ports.http.port }}:{{ .Values.service.ports.http.targetPort }}
+   Then connect to http://127.0.0.1:{{ .Values.service.ports.http.port }}{{ $path }}
+{{- end }}
+
+3. (Optional) Run the built-in connectivity test once the pod is ready:
+   helm test {{ .Release.Name }}
+
+4. Provide the `CLAUDE_CODE_OAUTH_TOKEN` value via `auth.claudeOAuthToken.*` and set
+   a secure admin password via `auth.adminPassword.*` before using the service.

--- a/charts/claude-code-api/templates/_helpers.tpl
+++ b/charts/claude-code-api/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{- define "claude-code-api-helm.name" -}}
+{{ include "mcp-library.name" . }}
+{{- end }}
+
+{{- define "claude-code-api-helm.fullname" -}}
+{{ include "mcp-library.fullname" . }}
+{{- end }}
+
+{{- define "claude-code-api-helm.chart" -}}
+{{ include "mcp-library.chart" . }}
+{{- end }}
+
+{{- define "claude-code-api-helm.labels" -}}
+{{ include "mcp-library.labels" . }}
+{{- end }}
+
+{{- define "claude-code-api-helm.selectorLabels" -}}
+{{ include "mcp-library.selectorLabels" . }}
+{{- end }}
+
+{{- define "claude-code-api-helm.serviceAccountName" -}}
+{{ include "mcp-library.serviceAccountName" . }}
+{{- end }}
+
+{{- define "claude-code-api-helm.authSecretName" -}}
+{{- if .Values.auth.secret.name -}}
+{{ .Values.auth.secret.name }}
+{{- else -}}
+{{ printf "%s-auth" (include "claude-code-api-helm.fullname" .) }}
+{{- end -}}
+{{- end }}
+
+{{- define "claude-code-api-helm.adminSecretName" -}}
+{{- if .Values.auth.adminPassword.existingSecret -}}
+{{ .Values.auth.adminPassword.existingSecret }}
+{{- else -}}
+{{ include "claude-code-api-helm.authSecretName" . }}
+{{- end -}}
+{{- end }}
+
+{{- define "claude-code-api-helm.tokenSecretName" -}}
+{{- if .Values.auth.claudeOAuthToken.existingSecret -}}
+{{ .Values.auth.claudeOAuthToken.existingSecret }}
+{{- else -}}
+{{ include "claude-code-api-helm.authSecretName" . }}
+{{- end -}}
+{{- end }}

--- a/charts/claude-code-api/templates/deployment.yaml
+++ b/charts/claude-code-api/templates/deployment.yaml
@@ -1,0 +1,132 @@
+{{- $tokenFromExisting := ne (trim .Values.auth.claudeOAuthToken.existingSecret) "" -}}
+{{- $tokenValueProvided := or (ne (trim .Values.auth.claudeOAuthToken.value) "") (ne (trim .Values.auth.claudeOAuthToken.valueBase64) "") -}}
+{{- if and (not $tokenValueProvided) (not $tokenFromExisting) -}}
+{{- fail "Provide Claude OAuth token via auth.claudeOAuthToken.value, valueBase64, or existingSecret" -}}
+{{- end -}}
+{{- if and $tokenFromExisting (eq (trim (.Values.auth.claudeOAuthToken.existingSecretKey | default "")) "") -}}
+{{- fail "Set auth.claudeOAuthToken.existingSecretKey when referencing an existing OAuth token secret" -}}
+{{- end -}}
+{{- $adminFromExisting := ne (trim .Values.auth.adminPassword.existingSecret) "" -}}
+{{- if and $adminFromExisting (eq (trim (.Values.auth.adminPassword.existingSecretKey | default "")) "") -}}
+{{- fail "Set auth.adminPassword.existingSecretKey when referencing an existing admin password secret" -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "claude-code-api-helm.fullname" . }}
+  labels:
+    {{- include "claude-code-api-helm.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "claude-code-api-helm.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "claude-code-api-helm.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "claude-code-api-helm.serviceAccountName" . }}
+      {{- if not (empty .Values.podSecurityContext) }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- if not (empty .Values.securityContext) }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
+          {{- $imageTag := default "" .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ ternary $imageTag .Chart.AppVersion (ne $imageTag "") }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: {{ .Values.auth.adminPassword.key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "claude-code-api-helm.adminSecretName" . }}
+                  key: {{ .Values.auth.adminPassword.existingSecretKey | default .Values.auth.adminPassword.key }}
+            - name: {{ .Values.auth.claudeOAuthToken.key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "claude-code-api-helm.tokenSecretName" . }}
+                  key: {{ .Values.auth.claudeOAuthToken.existingSecretKey | default .Values.auth.claudeOAuthToken.key }}
+            - name: PORT
+              value: {{ .Values.app.port | quote }}
+            - name: HTTPS_PORT
+              value: {{ .Values.app.httpsPort | quote }}
+            - name: NODE_ENV
+              value: {{ .Values.app.nodeEnv | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.app.logLevel | quote }}
+            {{- range $key, $val := .Values.env }}
+            - name: {{ $key }}
+              value: {{ quote $val }}
+            {{- end }}
+            {{- range $key, $val := .Values.envSecrets }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $val.secretName }}
+                  key: {{ $val.secretKey }}
+            {{- end }}
+            {{- if .Values.secretEnv.data }}
+            {{- range $key, $val := .Values.secretEnv.data }}
+            {{- if not (regexMatch "^[A-Za-z_][A-Za-z0-9_]*$" $key) }}
+              {{- fail (printf "secretEnv.data key '%s' must match ^[A-Za-z_][A-Za-z0-9_]*$" $key) -}}
+            {{- end }}
+            - name: {{ $key }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "claude-code-api-helm.fullname" $ }}
+                  key: {{ $key }}
+            {{- end }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.ports.http.targetPort | default .Values.app.port }}
+              protocol: TCP
+            {{- if .Values.service.ports.https.enabled }}
+            - name: https
+              containerPort: {{ .Values.service.ports.https.targetPort | default .Values.app.httpsPort }}
+              protocol: TCP
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /v1/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/claude-code-api/templates/hpa.yaml
+++ b/charts/claude-code-api/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "claude-code-api-helm.fullname" . }}
+  labels:
+    {{- include "claude-code-api-helm.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "claude-code-api-helm.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/claude-code-api/templates/ingress.yaml
+++ b/charts/claude-code-api/templates/ingress.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "claude-code-api-helm.fullname" . -}}
+{{- $svcPort := .Values.service.ports.http.port -}}
+{{- if and .Values.ingress.className (not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class")) }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+{{- end }}
+{{- include "mcp-library.ingressUseRegex" . }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "claude-code-api-helm.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- $ingressPath := include "mcp-library.ingressPath" . }}
+    {{- range .Values.ingress.hosts }}
+    -{{- if ne . "*" }} host: {{ . | quote }}{{- end }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            {{- if and $.Values.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ $.Values.ingress.pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/claude-code-api/templates/secret.yaml
+++ b/charts/claude-code-api/templates/secret.yaml
@@ -1,0 +1,48 @@
+{{- $useAdminSecret := not .Values.auth.adminPassword.existingSecret -}}
+{{- $useTokenSecret := not .Values.auth.claudeOAuthToken.existingSecret -}}
+{{- if and .Values.auth.secret.create (or $useAdminSecret $useTokenSecret) }}
+  {{- if and $useAdminSecret (and (eq (trim .Values.auth.adminPassword.value) "") (eq (trim .Values.auth.adminPassword.valueBase64) "")) -}}
+    {{- fail "Set auth.adminPassword.value or valueBase64 when managing the admin password secret" -}}
+  {{- end -}}
+  {{- if and $useTokenSecret (and (eq (trim .Values.auth.claudeOAuthToken.value) "") (eq (trim .Values.auth.claudeOAuthToken.valueBase64) "")) -}}
+    {{- fail "Set auth.claudeOAuthToken.value or valueBase64 when managing the OAuth token secret" -}}
+  {{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "claude-code-api-helm.authSecretName" . }}
+  labels:
+    {{- include "claude-code-api-helm.labels" . | nindent 4 }}
+  {{- with .Values.auth.secret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  {{ if $useAdminSecret }}
+  {{- $adminValue := .Values.auth.adminPassword.value | default "" -}}
+  {{- $adminValueBase64 := .Values.auth.adminPassword.valueBase64 | default "" -}}
+  {{ .Values.auth.adminPassword.key }}: {{ ternary $adminValueBase64 ($adminValue | b64enc) (ne (trim $adminValueBase64) "") }}
+  {{- end }}
+  {{ if $useTokenSecret }}
+  {{- $tokenValue := .Values.auth.claudeOAuthToken.value | default "" -}}
+  {{- $tokenValueBase64 := .Values.auth.claudeOAuthToken.valueBase64 | default "" -}}
+  {{ .Values.auth.claudeOAuthToken.key }}: {{ ternary $tokenValueBase64 ($tokenValue | b64enc) (ne (trim $tokenValueBase64) "") }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.secretEnv.data }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "claude-code-api-helm.fullname" . }}
+  labels:
+    {{- include "claude-code-api-helm.labels" . | nindent 4 }}
+type: Opaque
+# NOTE: For production deployments, prefer managing sensitive data in existing Secrets
+# or through an external secret manager instead of embedding it directly in values files.
+data:
+  {{- range $key, $val := .Values.secretEnv.data }}
+  {{ $key }}: {{ $val | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/claude-code-api/templates/service.yaml
+++ b/charts/claude-code-api/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "claude-code-api-helm.fullname" . }}
+  labels:
+    {{- include "claude-code-api-helm.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.ports.http.port }}
+      targetPort: {{ .Values.service.ports.http.targetPort }}
+      protocol: TCP
+      name: http
+    {{- if .Values.service.ports.https.enabled }}
+    - port: {{ .Values.service.ports.https.port }}
+      targetPort: {{ .Values.service.ports.https.targetPort }}
+      protocol: TCP
+      name: https
+    {{- end }}
+  selector:
+    {{- include "claude-code-api-helm.selectorLabels" . | nindent 4 }}

--- a/charts/claude-code-api/templates/serviceaccount.yaml
+++ b/charts/claude-code-api/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "claude-code-api-helm.serviceAccountName" . }}
+  labels:
+    {{- include "claude-code-api-helm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/claude-code-api/templates/tests/test-connection.yaml
+++ b/charts/claude-code-api/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "claude-code-api-helm.fullname" . }}-test-connection"
+  labels:
+    {{- include "claude-code-api-helm.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "claude-code-api-helm.fullname" . }}:{{ .Values.service.ports.http.port }}']
+  restartPolicy: Never

--- a/charts/claude-code-api/values.yaml
+++ b/charts/claude-code-api/values.yaml
@@ -1,0 +1,92 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/cabinlab/claude-code-api
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+service:
+  type: ClusterIP
+  ports:
+    http:
+      port: 8000
+      targetPort: 8000
+    https:
+      enabled: true
+      port: 8443
+      targetPort: 8443
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  path: /
+  pathType: Prefix
+  hosts:
+    - claude-code-api.local
+  tls: []
+
+resources: {}
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: ""
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+app:
+  port: 8000
+  httpsPort: 8443
+  nodeEnv: production
+  logLevel: info
+
+auth:
+  secret:
+    create: false
+    name: ""
+    annotations: {}
+
+  adminPassword:
+    key: ADMIN_PASSWORD
+    value: ""
+    valueBase64: ""
+    existingSecret: "claude-code-api-auth"
+    existingSecretKey: ADMIN_PASSWORD
+
+  claudeOAuthToken:
+    key: CLAUDE_CODE_OAUTH_TOKEN
+    value: ""
+    valueBase64: ""
+    existingSecret: "claude-code-api-auth"
+    existingSecretKey: CLAUDE_CODE_OAUTH_TOKEN
+
+env: {}
+
+envSecrets: {}
+
+secretEnv:
+  data: {}


### PR DESCRIPTION
This pull request introduces a new Helm chart for deploying the Claude Code API gateway, an OpenAI-compatible API with an admin UI for managing OAuth tokens. The addition includes all necessary chart files, documentation, and configuration to support flexible deployment in Kubernetes, including secret management, autoscaling, and ingress support.

**Key additions and changes:**

**1. New Helm Chart: `claude-code-api`**
- Adds a new Helm chart under `charts/claude-code-api` for deploying the Claude Code API gateway, including `Chart.yaml` and all required templates. The chart supports secret management, autoscaling, ingress, and resource configuration. [[1]](diffhunk://#diff-59fa30d0a56414fbbb8ab96ccf56b66109e1488b0c49ef2ef78ef3b3ca05a75cR1-R13) [[2]](diffhunk://#diff-42f49f10828cbf70140827d471d7f986f400f8529f8322c23b13f1255e58b70cR1-R143) [[3]](diffhunk://#diff-7ca92cbc5bb1f9fd6e33d95aaa5874d274c0b6fca60991e8393af65a6ff24f78R1-R132) [[4]](diffhunk://#diff-587f81d6c68c1f8cd18ab4e579ba57fddcd1118ff2c37c45066313d05786277fR1-R57) [[5]](diffhunk://#diff-f9bc1525b554de5c9d1645195c99d12b774719040e9ea98f755f885b0a8230efR1-R32) [[6]](diffhunk://#diff-11752058600cc441ab9d54e803d77d523706ca21a086312cd38fda6010f8db93R1-R48) [[7]](diffhunk://#diff-660fd61b37b1aa140a47c0011a77416437067a248416ac22700a5bbfe0fb26c9R1-R47) [[8]](diffhunk://#diff-bd72f9a49c09be0fa83ea0e276475be0951c36a21c59fe1add8b95fe13e4cd47R1-R41)

**2. Documentation**
- Provides a comprehensive `README.md` for the new chart, detailing prerequisites, installation/uninstallation steps, configuration parameters, and credential management.
- Updates the repository-level `README.md` to list the new `claude-code-api` chart and link to its documentation.

**3. Linting Configuration**
- Updates `.markdownlint.yaml` to disable rule MD060, likely to accommodate the new documentation style.

These changes collectively enable users to deploy and manage the Claude Code API gateway in Kubernetes using Helm, with secure and flexible configuration options.

## Summary by Sourcery

Add a Helm chart for deploying the Claude Code OpenAI-compatible API gateway, including configuration for secrets, autoscaling, ingress, and supporting Kubernetes resources.

New Features:
- Introduce the claude-code-api Helm chart with deployment, service, service account, and ingress support for the Claude Code API gateway.
- Provide configurable authentication handling for admin credentials and Claude OAuth tokens via managed or existing Kubernetes secrets.

Enhancements:
- Add optional Horizontal Pod Autoscaler configuration and resource settings for the claude-code-api deployment.
- Allow additional environment variables and secret-sourced environment configuration for the API gateway pods.

Documentation:
- Document installation, configuration parameters, credential management, and exposure options for the new claude-code-api chart in a dedicated README.
- Update the top-level repository README to list and link to the new claude-code-api chart.
- Relax markdownlint rule MD060 to accommodate the new documentation style.

Tests:
- Add a Helm test pod manifest to verify HTTP connectivity to the deployed claude-code-api service.