### PR TITLE
Switch claude-code-api default image to Docker Hub and bump chart version

### DIFF
--- a/charts/claude-code-api/Chart.yaml
+++ b/charts/claude-code-api/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://raw.githubusercontent.com/modelcontextprotocol/docs/main/logo/ligh
 
 type: application
 
-version: 0.1.0
+version: 0.1.1
 dependencies:
   - name: mcp-library
     version: 0.1.4

--- a/charts/claude-code-api/README.md
+++ b/charts/claude-code-api/README.md
@@ -41,7 +41,7 @@ helm delete claude-code-api
 
 | Name | Description | Value |
 | --- | --- | --- |
-| `image.repository` | Container image repository | `ghcr.io/cabinlab/claude-code-api` |
+| `image.repository` | Container image repository | `arbuzov/claude-code-api` |
 | `image.tag` | Container image tag (defaults to chart `appVersion` when empty) | `""` |
 | `image.pullPolicy` | Container image pull policy | `IfNotPresent` |
 | `imagePullSecrets` | Kubernetes image pull secrets | `[]` |

--- a/charts/claude-code-api/values.yaml
+++ b/charts/claude-code-api/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cabinlab/claude-code-api
+  repository: arbuzov/claude-code-api
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
### Motivation
- Artifact Hub Trivy scans intermittently fail for `ghcr.io/cabinlab/claude-code-api` due to access and platform errors, so a Docker Hub mirror is preferred to avoid GHCR access/manifest issues. 
- The chart should default to a reachable public image repository that the maintainer controls to improve reliability. 
- The chart version is bumped to reflect the packaging change to the default image.

### Description
- Updated `charts/claude-code-api/values.yaml` to set `image.repository` to `arbuzov/claude-code-api` instead of `ghcr.io/cabinlab/claude-code-api`.
- Updated `charts/claude-code-api/README.md` to document the new default image repository.
- Bumped `charts/claude-code-api/Chart.yaml` version from `0.1.0` to `0.1.1` to indicate the chart change.

### Testing
- No automated tests were executed for this change.
- Chart linting or packaging was not run as part of this update.
- Manual verification consisted of reviewing updated files and diffs which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cfb01fdf48320b282d056fa10880b)

## Summary by Sourcery

Update claude-code-api Helm chart to use a new default container image repository and bump the chart version.

Enhancements:
- Change the default claude-code-api container image repository from GHCR to the Docker Hub mirror in chart values.
- Update the chart README to document the new default image repository.
- Bump the claude-code-api chart version from 0.1.0 to 0.1.1 to reflect the image repository change.