### PR TITLE
Update default search crawler image to laituanmanh/websearch-crawler

### DIFF
--- a/charts/search/README.md
+++ b/charts/search/README.md
@@ -31,7 +31,7 @@ helm install search ./charts/search \
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `replicaCount` | Number of crawler pods to run. | `1` |
-| `crawler.image.repository` | Container image for the crawler service. | `ghcr.io/modelcontextprotocol/search` |
+| `crawler.image.repository` | Container image for the crawler service. | `laituanmanh/websearch-crawler` |
 | `crawler.service.port` | Container port exposed by the crawler. | `8080` |
 | `crawler.env` | Key/value environment variables for the crawler container. | `{}` |
 | `flaresolverr.image.repository` | Container image for FlareSolverr. | `ghcr.io/flaresolverr/flaresolverr` |

--- a/charts/search/values.yaml
+++ b/charts/search/values.yaml
@@ -16,7 +16,7 @@ serviceAccount:
 
 crawler:
   image:
-    repository: ghcr.io/modelcontextprotocol/search
+    repository: laituanmanh/websearch-crawler
     tag: latest
     pullPolicy: IfNotPresent
   service:


### PR DESCRIPTION
### Motivation
- The default crawler image referenced a GHCR image that caused access/scan errors when pulled by tooling. 
- Swap to a publicly accessible image to avoid denied access from `ghcr.io` during scans and deployments. 

### Description
- Change default crawler image repository in `charts/search/values.yaml` from `ghcr.io/modelcontextprotocol/search` to `laituanmanh/websearch-crawler`. 
- Update `charts/search/README.md` to reflect the new default `crawler.image.repository` value. 
- No other chart behavior or configuration values were altered. 

### Testing
- No automated tests were executed as part of this change. 
- No `helm lint` or template validation was run automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952daa7555083208d26efeda8864462)

## Summary by Sourcery

Update the search Helm chart to use a new default crawler image repository that is publicly accessible.

Enhancements:
- Change the default crawler image repository to laituanmanh/websearch-crawler in the search Helm chart values.
- Align the search chart README documentation with the new default crawler image repository.