### PR TITLE
Fix gh-pages authentication in chart-release workflow

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -69,7 +69,8 @@ jobs:
           tmpdir="$(mktemp -d)"
           trap 'rm -rf "${tmpdir}"' EXIT
 
-          git -C "${tmpdir}" clone --branch gh-pages --depth 1 "https://github.com/${repo}.git" gh-pages \
+          git -C "${tmpdir}" clone --branch gh-pages --depth 1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/${repo}.git" gh-pages \
             || { echo "gh-pages branch not found; nothing to clean up."; exit 0; }
           cd "${tmpdir}/gh-pages"
 
@@ -87,7 +88,7 @@ jobs:
           fi
 
           git commit -m "Remove ${CHART} ${VERSION} from index"
-          git push origin gh-pages
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${repo}.git" gh-pages
 
   release_library:
     needs: manage_release


### PR DESCRIPTION
### Motivation
- The release workflow needs to delete or reupload chart artifacts on the `gh-pages` branch and must authenticate git operations when running in CI. 
- Anonymous clone/push can fail when the workflow needs to modify the `gh-pages` branch during `delete` or `reupload` actions. 
- Use the workflow token to allow the job to clone and push the `gh-pages` branch reliably.

### Description
- Update the `git clone` command in `.github/workflows/chart-release.yml` to use an authenticated URL with `GH_TOKEN` as `https://x-access-token:${GH_TOKEN}@github.com/${repo}.git`.
- Update the `git push` invocation to push via the same authenticated HTTPS URL using `GH_TOKEN`.
- Preserve the existing behavior when the `gh-pages` branch is not present by keeping the same fallback logic.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952dc3a0f748320b16dc6f632bcf184)

## Summary by Sourcery

CI:
- Authenticate git clone and push operations in the chart-release workflow using GH_TOKEN when interacting with the gh-pages branch, while preserving existing fallback behavior if the branch is missing.