### PR TITLE
Fix yamllint issues in chart release workflow

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -71,47 +71,58 @@ jobs:
 
           targets_file="${tmpdir}/targets.txt"
           python - "${CHART}" "${VERSION}" "${targets_file}" <<'PY'
-import sys
-from pathlib import Path
-import yaml
+          import sys
+          from pathlib import Path
+          import yaml
 
-chart = sys.argv[1]
-version = sys.argv[2]
-targets_path = Path(sys.argv[3])
-index_path = Path("index.yaml")
+          chart = sys.argv[1]
+          version = sys.argv[2]
+          targets_path = Path(sys.argv[3])
+          index_path = Path("index.yaml")
 
-data = {}
-if index_path.exists():
-    with index_path.open() as handle:
-        data = yaml.safe_load(handle) or {}
+          data = {}
+          if index_path.exists():
+              with index_path.open() as handle:
+                  data = yaml.safe_load(handle) or {}
 
-entries = data.get("entries", {})
-targets = []
+          entries = data.get("entries", {})
+          targets = []
 
-if chart == "all" and version == "all":
-    for chart_name, chart_entries in entries.items():
-        for entry in chart_entries:
-            entry_version = entry.get("version")
-            if entry_version:
-                targets.append((chart_name, entry_version))
-    data["entries"] = {}
-elif version == "all":
-    chart_entries = entries.get(chart, [])
-    targets = [(chart, entry.get("version")) for entry in chart_entries if entry.get("version")]
-    entries[chart] = []
-    data["entries"] = entries
-else:
-    targets = [(chart, version)]
-    chart_entries = entries.get(chart, [])
-    entries[chart] = [entry for entry in chart_entries if entry.get("version") != version]
-    data["entries"] = entries
+          if chart == "all" and version == "all":
+              for chart_name, chart_entries in entries.items():
+                  for entry in chart_entries:
+                      entry_version = entry.get("version")
+                      if entry_version:
+                          targets.append((chart_name, entry_version))
+              data["entries"] = {}
+          elif version == "all":
+              chart_entries = entries.get(chart, [])
+              targets = [
+                  (chart, entry.get("version"))
+                  for entry in chart_entries
+                  if entry.get("version")
+              ]
+              entries[chart] = []
+              data["entries"] = entries
+          else:
+              targets = [(chart, version)]
+              chart_entries = entries.get(chart, [])
+              entries[chart] = [
+                  entry for entry in chart_entries if entry.get("version") != version
+              ]
+              data["entries"] = entries
 
-targets_path.write_text("\n".join(f"{chart_name} {version_name}" for chart_name, version_name in targets))
+          targets_path.write_text(
+              "\n".join(
+                  f"{chart_name} {version_name}"
+                  for chart_name, version_name in targets
+              )
+          )
 
-if index_path.exists():
-    with index_path.open("w") as handle:
-        yaml.safe_dump(data, handle, sort_keys=False)
-PY
+          if index_path.exists():
+              with index_path.open("w") as handle:
+                  yaml.safe_dump(data, handle, sort_keys=False)
+          PY
 
           if [[ ! -s "${targets_file}" ]]; then
             if [[ "${CHART}" == "all" || "${VERSION}" == "all" ]]; then

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,3 +1,6 @@
 extends: relaxed
 ignore: |
   charts/*/templates/*
+rules:
+  line-length:
+    max: 160

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -2,4 +2,3 @@ repositoryID: 48fd68da-25bc-4207-9aeb-e731542de28b
 owners:
   - name: Serge Arbuzov
     email: info@whitediver.com
-


### PR DESCRIPTION
### Motivation

- CI linting was failing due to a YAML syntax problem in the chart release workflow heredoc and strict line-length checks.  
- The embedded Python heredoc needed consistent indentation so the surrounding YAML remains valid.  
- Existing YAML files contain longer lines that trigger `yamllint` warnings; the config should match repository conventions.  

### Description

- Rewrote the embedded Python heredoc in `.github/workflows/chart-release.yml` with corrected indentation and wrapped long expressions to improve readability.  
- Relaxed the `yamllint` `line-length` rule by adding `rules: line-length: max: 160` to `.yamllint.yml`.  
- Removed a trailing blank line from `artifacthub-repo.yml` to fix an `yamllint` empty-lines warning.  

### Testing

- Ran `yamllint .` and it completed without errors.  
- Ran `markdownlint '**/*.md'` and it completed successfully.  
- Verified repository status reflects the three updated files: `chart-release.yml`, `.yamllint.yml`, and `artifacthub-repo.yml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cbd8ea0bc8320804e5e174a2efb68)

## Summary by Sourcery

Fix YAML and embedded Python formatting in the chart release workflow and align yamllint configuration with repository conventions.

Bug Fixes:
- Correct YAML indentation of the embedded Python heredoc in the chart release workflow to resolve CI linting failures.
- Remove an extra trailing blank line from artifacthub-repo.yml to satisfy yamllint empty-lines rules.

Enhancements:
- Reformat the embedded Python script in the chart release workflow to improve readability and maintainability.
- Relax yamllint line-length configuration to allow lines up to 160 characters in line with existing YAML usage.