### PR TITLE
Add chart choices to release workflow dispatch input

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -19,7 +19,19 @@ on:
         default: release
       chart:
         description: Chart name for delete/reupload (e.g. mcpo, or all for every chart)
-        type: string
+        type: choice
+        options:
+          - all
+          - atlassian
+          - claude-code-api
+          - copilot-api
+          - gitlab
+          - homeassistant
+          - kubernetes
+          - mcpo
+          - mcp-library
+          - playwright
+          - search
         required: false
       version:
         description: Chart version for delete/reupload (e.g. 0.3.2, or all for every version)


### PR DESCRIPTION
### Motivation
- Ensure the `chart` workflow_dispatch input is presented as a controlled dropdown rather than a freeform string to avoid invalid values.
- Make the dispatch UI explicitly include the `all` option so bulk operations match the workflow logic.
- Improve UX in the GitHub Actions UI so reviewers/operators can pick a chart from a list instead of typing a name.

### Description
- Change the `chart` input in ` .github/workflows/chart-release.yml` from `type: string` to `type: choice` and provide an explicit options list. 
- Add the `all` option plus each chart name (`atlassian`, `claude-code-api`, `copilot-api`, `gitlab`, `homeassistant`, `kubernetes`, `mcpo`, `mcp-library`, `playwright`, `search`) to the choices. 
- Leave other workflow logic intact so existing `delete`/`reupload` behavior is unchanged.

### Testing
- No automated tests were run because this change only updates workflow metadata and UI inputs.
- Manual verification is expected by triggering the workflow_dispatch in the repository UI to confirm the dropdown appears and contains the new choices.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d0129364083208dd43e701ec757a9)

## Summary by Sourcery

CI:
- Update the chart-release GitHub Actions workflow to use a choice-type input with a fixed list of chart names for the chart parameter.