### PR TITLE
AI-22 mcpo healthcheck

### DIFF
--- a/charts/mcpo/templates/deployment.yaml
+++ b/charts/mcpo/templates/deployment.yaml
@@ -79,20 +79,28 @@ spec:
             - name: config
               mountPath: /opt/mcpo/config.json
               subPath: config.json
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /openapi.json
+              path: {{ .Values.livenessProbe.path }}
               port: http
               scheme: HTTP
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /openapi.json
+              path: {{ .Values.readinessProbe.path }}
               port: http
               scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/mcpo/templates/deployment.yaml
+++ b/charts/mcpo/templates/deployment.yaml
@@ -79,28 +79,20 @@ spec:
             - name: config
               mountPath: /opt/mcpo/config.json
               subPath: config.json
-          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.livenessProbe.path }}
+              path: /healthz
               port: http
               scheme: HTTP
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-          {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: {{ .Values.readinessProbe.path }}
+              path: /healthz
               port: http
               scheme: HTTP
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-          {{- end }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/mcpo/values.yaml
+++ b/charts/mcpo/values.yaml
@@ -95,6 +95,22 @@ envSecrets: {}
 secretEnv:
   data: {}
 
+livenessProbe:
+  enabled: true
+  path: /healthz
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  path: /healthz
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 1
+  failureThreshold: 3
+
 # Configuration file contents for mcpo. Values will be rendered as JSON in
 # `config.json` and mounted to the container.
 config:

--- a/charts/mcpo/values.yaml
+++ b/charts/mcpo/values.yaml
@@ -95,22 +95,6 @@ envSecrets: {}
 secretEnv:
   data: {}
 
-livenessProbe:
-  enabled: true
-  path: /healthz
-  initialDelaySeconds: 30
-  periodSeconds: 10
-  timeoutSeconds: 1
-  failureThreshold: 3
-
-readinessProbe:
-  enabled: true
-  path: /healthz
-  initialDelaySeconds: 5
-  periodSeconds: 5
-  timeoutSeconds: 1
-  failureThreshold: 3
-
 # Configuration file contents for mcpo. Values will be rendered as JSON in
 # `config.json` and mounted to the container.
 config:


### PR DESCRIPTION
mcpo restarting if any of mcps were restarted

## Summary by Sourcery

Parameterize and enable configurable liveness and readiness probes for the mcpo deployment using Helm values.

New Features:
- Add configurable liveness and readiness probes paths and timing settings for the mcpo service via values.yaml.

Enhancements:
- Allow liveness and readiness probes to be toggled on or off and customized through Helm values instead of hardcoded settings.